### PR TITLE
Add case-insensitive file extension support for metadata extraction

### DIFF
--- a/docs/changes/4.bugfix.rst
+++ b/docs/changes/4.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed issue where mixed-case or upper-case extensions were not being properly assigned to the correct extractors.

--- a/nexusLIMS/extractors/__init__.py
+++ b/nexusLIMS/extractors/__init__.py
@@ -183,7 +183,7 @@ def parse_metadata(
     extension = fname.suffix[1:]
 
     # Dealing with files we can't parse and extract
-    if extension not in extension_reader_map:
+    if extension.lower() not in extension_reader_map:
         extractor_method = get_basic_metadata
         if extension not in unextracted_preview_map:
             generate_preview = False
@@ -200,7 +200,7 @@ def parse_metadata(
             )
 
     else:
-        extractor_method = extension_reader_map[extension]
+        extractor_method = extension_reader_map[extension.lower()]
 
     nx_meta = extractor_method(fname)
     nx_meta = _add_extraction_details(nx_meta, extractor_method)


### PR DESCRIPTION
Update `parse_metadata` function to normalize file extensions to lowercase before lookup in extension_reader_map. Add tests for mixed-case extensions (.Dm4, .TIF) to verify metadata extraction works with uppercase and mixed-case file extensions.

Resolves #4 