### PR TITLE
Miscellaneous small enhancements (docs, mostly)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ labarchives_api_docs
 
 # Other files
 TODO.md
+notes.md
 nemo_api_schemas
 .access_token
 gitlab_backup.log

--- a/docs/changes/+ca.doc.md
+++ b/docs/changes/+ca.doc.md
@@ -1,0 +1,1 @@
+Added note to {ref}`Local Test Deployment <cdcs-local-test-deployment>` docs about the need to set `NX_CERT_BUNDLE_FILE` in the backend when using `mkcert`.

--- a/docs/changes/+pypi.misc.md
+++ b/docs/changes/+pypi.misc.md
@@ -1,0 +1,1 @@
+Updated links to project homepage and documentation for PyPI release info.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nexusLIMS"
-version = "2.4.0"
+version = "2.4.1.dev0"
 description = "Electron Microscopy Nexus LIMS project (Datasophos fork)"
 authors = [
     {name = "Joshua Taillon", email = "josh@datasophos.co"}
@@ -80,9 +80,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/datasophos/NexusLIMS"
+Homepage = "https://datasophos.github.io/NexusLIMS/stable"
 Repository = "https://github.com/datasophos/NexusLIMS.git"
-Documentation = "https://github.com/datasophos/NexusLIMS"
+Documentation = "https://datasophos.github.io/NexusLIMS/stable"
 "Original-NIST-Repository" = "https://github.com/usnistgov/NexusLIMS.git"
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -1293,7 +1293,7 @@ wheels = [
 
 [[package]]
 name = "nexuslims"
-version = "2.4.0.dev0"
+version = "2.4.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
- Document the need to set `NX_CERT_BUNDLE_FILE` to the mkcert rootCA.pem in the backend .env when using the local test deployment. Python's requests library does not use the OS trust store, so mkcert -install alone is insufficient for the record builder to reach CDCS over HTTPS.
- Add a troubleshooting entry for the resulting SSLCertVerificationError.
- Update Homepage and Documentation URLs in pyproject.toml to point to the docs site.
- Add notes.md to .gitignore.