### PR TITLE
docs: Audit and update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@
 
 ## The following variable defines whether the file finding will be "exclusive",
 ## meaning that records will only include files for which NexusLIMS has an explicit
-## metadata extractor defined (see https://pages.nist.gov/NexusLIMS/api/nexusLIMS.extractors.html),
+## metadata extractor defined (see https://datasophos.github.io/NexusLIMS/stable/),
 ## or "inclusive", meaning that records will include all files, with basic
 ## metadata defined for files without a NexusLIMS extractor. The variable should
 ## be either the string 'exclusive' or 'inclusive'. If no value (or a value other than
@@ -24,29 +24,29 @@ NX_FILE_STRATEGY='exclusive'
 ## by commas. The patterns should follow the same syntax as the '-name' argument
 ## to the GNU find command (see https://manpages.org/find)
 
-NX_IGNORE_PATTERNS='["*.mib","*.db","*.emi"]'
+NX_IGNORE_PATTERNS='["*.mib","*.db","*.emi","*.hdr"]'
 
 ## The following value is used to authenticate to the
 ## CDCS API for uploading built records to the
-## front-end record repository (see https://github.com/usnistgov/NexusLIMS-CDCS).
+## front-end record repository (see https://github.com/datasophos/NexusLIMS-CDCS).
 ## Obtain this token from the CDCS admin panel or via the API token endpoint.
 
 NX_CDCS_TOKEN='your-api-token-here'
 
 ## The following value should be set to the root URL of the NexusLIMS CDCS
-## front-end (the one installed using https://github.com/usnistgov/NexusLIMS-CDCS).
+## front-end (the one installed using https://github.com/datasophos/NexusLIMS-CDCS).
 ## This will be the target for record uploads using the NX_CDCS_TOKEN above
 ## (should include the trailing slash)
 
 NX_CDCS_URL='https://nexuslims.domain.com/'
 
-## The following value (for development) should be set to the root URL of a
-## NexusLIMS CDCS instance to use for testing. If defined, this URL will be
-## used for the CDCS tests rather than the "actual" URL defined above. If not
-## defined, the CDCS tests will be skipped so the tests do not impact the production
-## deployment.
+## The following variable defines the strategy for exporting records to multiple
+## destinations (CDCS, eLabFTW, etc.). Options are:
+##   'all' (default): All destinations must succeed or the export fails
+##   'first_success': Stop after the first successful export
+##   'best_effort': Try all destinations, succeed if any succeed
 
-# NX_TEST_CDCS_URL='https://test.nexuslims.domain.com/'
+# NX_EXPORT_STRATEGY='all'
 
 ## If you need a custom SSL certificate CA bundle to verify requests to the
 ## "NX_CDCS_URL" or NEMO URLs, provide the path to that bundle here and uncomment
@@ -189,7 +189,7 @@ NX_CLUSTERING_SENSITIVITY=1.0
 ## to allow for support of non-default date format settings on a NEMO server.
 ## The formats should be provided using the standard datetime library syntax for
 ## encoding date and time information (see
-## https://docs.python.org/3.7/library/datetime.html?highlight=datetime#strftime-strptime-behavior)
+## https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes)
 
 # format to send to filter API responses
 # NX_NEMO_STRFTIME_FMT_1="%Y-%m-%dT%H:%M:%S%z"

--- a/docs/changes/53.doc.md
+++ b/docs/changes/53.doc.md
@@ -1,0 +1,1 @@
+Updated `.env.example` to match current configuration surface and documentation standards. Fixed stale repository links pointing to NIST infrastructure, removed unused `NX_TEST_CDCS_URL` variable, added missing `NX_EXPORT_STRATEGY` setting, synchronized `NX_IGNORE_PATTERNS` default value with code, and updated Python documentation link to version-agnostic URL.


### PR DESCRIPTION
## Summary
Fixes #53

Updated `.env.example` to match the current configuration surface in `nexusLIMS/config.py`:
- Fixed stale repository links pointing to NIST infrastructure (→ Datasophos)
- Removed unused `NX_TEST_CDCS_URL` variable
- Added missing `NX_EXPORT_STRATEGY` setting with description
- Synchronized `NX_IGNORE_PATTERNS` default value (added `*.hdr`)
- Updated Python documentation link to version-agnostic URL

## Test plan
- [x] All URLs validated as accessible
- [x] Default values verified against `nexusLIMS/config.py`
- [x] Linting passes (`ruff format` and `ruff check`)
- [x] Pre-commit hooks passed