### PR TITLE
feat: add preflight checks to record builder startup

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+# Path to migration scripts (relative to this file / project root)
+script_location = nexusLIMS/db/migrations

--- a/docs/changes/57.feature.md
+++ b/docs/changes/57.feature.md
@@ -1,0 +1,1 @@
+Added preflight checks that run at the start of `nexuslims build-records`. Common misconfigurations — such as a missing or outdated database schema, invalid instrument timezones, unwritable data directories, and unreachable export destinations — are now detected and reported with actionable error messages before any harvesting or record-building work begins.

--- a/nexusLIMS/builder/preflight.py
+++ b/nexusLIMS/builder/preflight.py
@@ -1,0 +1,822 @@
+"""Preflight checks for the NexusLIMS record builder.
+
+This module provides a ``run_preflight_checks()`` function that validates
+the environment before the record builder starts any harvesting or record
+building work. Misconfigurations are caught early and reported with
+actionable messages.
+
+Attributes
+----------
+CheckResult
+    Dataclass representing the result of a single preflight check.
+PreflightError
+    Exception raised when one or more error-severity checks fail.
+"""
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from importlib import import_module
+from pathlib import Path
+from typing import Literal
+
+import pytz
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import text
+from sqlmodel import Session as DBSession
+from sqlmodel import SQLModel, select
+
+from nexusLIMS.config import settings
+from nexusLIMS.db.engine import get_engine
+from nexusLIMS.db.models import (  # noqa: F401 — imported to populate SQLModel.metadata
+    ExternalUserIdentifier,
+    Instrument,
+    SessionLog,
+    UploadLog,
+)
+from nexusLIMS.exporters.registry import get_registry
+from nexusLIMS.harvesters.nemo.utils import get_harvesters_enabled
+from nexusLIMS.utils.network import nexus_req
+
+_logger = logging.getLogger(__name__)
+
+# Absolute path to alembic.ini at the project root (CWD-independent)
+_ALEMBIC_INI_PATH = Path(__file__).parents[2] / "alembic.ini"
+
+
+@dataclass
+class CheckResult:
+    """Result of a single preflight check.
+
+    Parameters
+    ----------
+    name
+        Short label for the check (e.g. ``"db_tables"``).
+    passed
+        Whether the check passed.
+    severity
+        ``"error"`` if the check failure means the run cannot succeed;
+        ``"warning"`` if suspicious but the run may still succeed.
+    message
+        Human-readable, actionable description of the result.
+    """
+
+    name: str
+    passed: bool
+    severity: Literal["error", "warning"]
+    message: str
+
+
+class PreflightError(Exception):
+    """Raised when one or more preflight checks with severity='error' fail.
+
+    Parameters
+    ----------
+    failed_checks
+        The list of failed :class:`CheckResult` objects with
+        ``severity="error"``.
+    """
+
+    def __init__(self, failed_checks: list[CheckResult]) -> None:
+        self.failed_checks = failed_checks
+        names = ", ".join(c.name for c in failed_checks)
+        super().__init__(f"Preflight checks failed: {names}")
+
+
+# ---------------------------------------------------------------------------
+# Individual check helpers
+# ---------------------------------------------------------------------------
+
+
+def _check_db_reachable() -> CheckResult:
+    """Check that the SQLite database file exists and is connectable."""
+    name = "db_reachable"
+    db_path = Path(settings.NX_DB_PATH)
+
+    if not db_path.exists():
+        return CheckResult(
+            name=name,
+            passed=False,
+            severity="error",
+            message=(
+                f"Database file not found: {db_path}. "
+                "Run 'nexuslims db init' to create the database."
+            ),
+        )
+
+    try:
+        with DBSession(get_engine()) as session:
+            session.exec(text("SELECT 1"))  # type: ignore[call-overload]
+    except Exception as exc:
+        return CheckResult(
+            name=name,
+            passed=False,
+            severity="error",
+            message=(
+                f"Cannot connect to database at {db_path}: {exc}. "
+                "Ensure the file is a valid SQLite database."
+            ),
+        )
+
+    return CheckResult(
+        name=name,
+        passed=True,
+        severity="error",
+        message=f"Database reachable at {db_path}.",
+    )
+
+
+def _check_db_tables() -> CheckResult:
+    """Check that all expected ORM tables exist in the database."""
+    name = "db_tables"
+
+    # SQLModel.metadata.tables is populated by the model imports at module top
+    expected = set(SQLModel.metadata.tables.keys())
+
+    try:
+        with DBSession(get_engine()) as session:
+            rows = session.exec(
+                text("SELECT name FROM sqlite_master WHERE type='table'")  # type: ignore[call-overload]
+            ).all()
+        actual = {row[0] for row in rows}
+    except Exception as exc:
+        return CheckResult(
+            name=name,
+            passed=False,
+            severity="error",
+            message=f"Could not query database tables: {exc}",
+        )
+
+    missing = expected - actual
+    if missing:
+        return CheckResult(
+            name=name,
+            passed=False,
+            severity="error",
+            message=(
+                f"Missing tables: {', '.join(sorted(missing))}. "
+                "Run 'nexuslims db upgrade' to apply migrations."
+            ),
+        )
+
+    return CheckResult(
+        name=name,
+        passed=True,
+        severity="error",
+        message=f"All expected tables present: {', '.join(sorted(expected))}.",
+    )
+
+
+def _check_alembic_migration() -> CheckResult:
+    """Check that the database schema is at the latest Alembic migration."""
+    name = "alembic_migration"
+
+    try:
+        cfg = Config(str(_ALEMBIC_INI_PATH))
+        # script_location in alembic.ini is a relative path; resolve it to an
+        # absolute path so the check works regardless of CWD.
+        cfg.set_main_option(
+            "script_location",
+            str(_ALEMBIC_INI_PATH.parent / "nexusLIMS" / "db" / "migrations"),
+        )
+        script = ScriptDirectory.from_config(cfg)
+        head_rev = script.get_current_head()
+    except Exception as exc:
+        return CheckResult(
+            name=name,
+            passed=False,
+            severity="error",
+            message=f"Could not determine Alembic head revision: {exc}",
+        )
+
+    if head_rev is None:
+        # No migrations defined yet — nothing to check
+        return CheckResult(
+            name=name,
+            passed=True,
+            severity="error",
+            message="No Alembic revisions found; skipping migration check.",
+        )
+
+    # Query current revision from the database
+    try:
+        with DBSession(get_engine()) as session:
+            # Check if alembic_version table exists first
+            tables_result = session.exec(
+                text(  # type: ignore[call-overload]
+                    "SELECT name FROM sqlite_master WHERE type='table' "
+                    "AND name='alembic_version'"
+                )
+            ).first()
+            if tables_result is None:
+                return CheckResult(
+                    name=name,
+                    passed=False,
+                    severity="error",
+                    message=(
+                        "alembic_version table not found — database is not managed by "
+                        "Alembic. Run 'nexuslims db upgrade' to initialise migrations."
+                    ),
+                )
+            current_rev = session.exec(
+                text("SELECT version_num FROM alembic_version")  # type: ignore[call-overload]
+            ).first()
+    except Exception as exc:
+        return CheckResult(
+            name=name,
+            passed=False,
+            severity="error",
+            message=f"Could not query alembic_version: {exc}",
+        )
+
+    current = current_rev[0] if current_rev else None
+
+    if current == head_rev:
+        return CheckResult(
+            name=name,
+            passed=True,
+            severity="error",
+            message=f"Database schema is up to date (revision {current}).",
+        )
+
+    return CheckResult(
+        name=name,
+        passed=False,
+        severity="error",
+        message=(
+            f"Database schema is out of date: current={current!r}, "
+            f"head={head_rev!r}. Run 'nexuslims db upgrade' to apply pending "
+            "migrations."
+        ),
+    )
+
+
+def _check_instruments_exist() -> CheckResult:
+    """Check that at least one instrument is registered in the database."""
+    name = "instruments_exist"
+
+    try:
+        with DBSession(get_engine()) as session:
+            count = session.exec(
+                text("SELECT COUNT(*) FROM instruments")  # type: ignore[call-overload]
+            ).first()
+        n = count[0] if count else 0
+    except Exception as exc:
+        return CheckResult(
+            name=name,
+            passed=False,
+            severity="warning",
+            message=f"Could not query instruments table: {exc}",
+        )
+
+    if n == 0:
+        return CheckResult(
+            name=name,
+            passed=False,
+            severity="warning",
+            message=(
+                "No instruments found in the database. "
+                "Add instruments with 'nexuslims instruments add' before building "
+                "records."
+            ),
+        )
+
+    return CheckResult(
+        name=name,
+        passed=True,
+        severity="warning",
+        message=f"Found {n} instrument(s) in the database.",
+    )
+
+
+def _check_instrument_filestore_paths() -> list[CheckResult]:
+    """Check each instrument filestore path exists under NX_INSTRUMENT_DATA_PATH."""
+    name = "instrument_filestore_paths"
+    base = Path(settings.NX_INSTRUMENT_DATA_PATH)
+
+    if not base.exists():
+        return [
+            CheckResult(
+                name=name,
+                passed=False,
+                severity="warning",
+                message=(
+                    f"NX_INSTRUMENT_DATA_PATH ({base}) does not exist or is not "
+                    "mounted. Instrument file searches will fail."
+                ),
+            )
+        ]
+
+    try:
+        with DBSession(get_engine()) as session:
+            instruments = session.exec(select(Instrument)).all()
+    except Exception as exc:
+        return [
+            CheckResult(
+                name=name,
+                passed=False,
+                severity="warning",
+                message=f"Could not query instruments for filestore path check: {exc}",
+            )
+        ]
+
+    if not instruments:
+        return [
+            CheckResult(
+                name=name,
+                passed=True,
+                severity="warning",
+                message="No instruments in DB; skipping filestore path check.",
+            )
+        ]
+
+    results = []
+    for instr in instruments:
+        path = base / instr.filestore_path
+        if not path.exists():
+            results.append(
+                CheckResult(
+                    name=name,
+                    passed=False,
+                    severity="warning",
+                    message=(
+                        f"Instrument '{instr.instrument_pid}': filestore path "
+                        f"{path} does not exist."
+                    ),
+                )
+            )
+
+    if not results:
+        return [
+            CheckResult(
+                name=name,
+                passed=True,
+                severity="warning",
+                message=(
+                    f"All {len(instruments)} instrument filestore path(s) exist "
+                    f"under {base}."
+                ),
+            )
+        ]
+
+    return results
+
+
+def _check_instrument_harvesters() -> list[CheckResult]:
+    """Check that each instrument's harvester module is importable and complete."""
+    name = "instrument_harvesters"
+
+    try:
+        with DBSession(get_engine()) as session:
+            instruments = session.exec(select(Instrument)).all()
+    except Exception as exc:
+        return [
+            CheckResult(
+                name=name,
+                passed=False,
+                severity="error",
+                message=f"Could not query instruments for harvester check: {exc}",
+            )
+        ]
+
+    if not instruments:
+        return [
+            CheckResult(
+                name=name,
+                passed=True,
+                severity="error",
+                message="No instruments in DB; skipping harvester check.",
+            )
+        ]
+
+    # Group instruments by harvester name
+    harvester_to_instruments: dict[str, list[str]] = {}
+    for instr in instruments:
+        harvester_to_instruments.setdefault(instr.harvester, []).append(
+            instr.instrument_pid
+        )
+
+    results = []
+    for harvester_name, pids in harvester_to_instruments.items():
+        instrument_list = ", ".join(pids)
+        try:
+            module = import_module(f".{harvester_name}", "nexusLIMS.harvesters")
+        except ImportError as exc:
+            results.append(
+                CheckResult(
+                    name=name,
+                    passed=False,
+                    severity="error",
+                    message=(
+                        f"Harvester module '{harvester_name}' cannot be imported: "
+                        f"{exc}. Affected instruments: {instrument_list}."
+                    ),
+                )
+            )
+            continue
+
+        if not hasattr(module, "res_event_from_session"):
+            results.append(
+                CheckResult(
+                    name=name,
+                    passed=False,
+                    severity="error",
+                    message=(
+                        f"Harvester '{harvester_name}' is missing required function "
+                        f"'res_event_from_session'. Affected instruments: "
+                        f"{instrument_list}."
+                    ),
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    name=name,
+                    passed=True,
+                    severity="error",
+                    message=(
+                        f"Harvester '{harvester_name}' OK "
+                        f"(instruments: {instrument_list})."
+                    ),
+                )
+            )
+
+    return results
+
+
+def _check_instrument_timezones() -> list[CheckResult]:
+    """Check that each instrument's timezone string is a valid IANA timezone."""
+    name = "instrument_timezones"
+
+    try:
+        with DBSession(get_engine()) as session:
+            instruments = session.exec(select(Instrument)).all()
+    except Exception as exc:
+        return [
+            CheckResult(
+                name=name,
+                passed=False,
+                severity="warning",
+                message=f"Could not query instruments for timezone check: {exc}",
+            )
+        ]
+
+    if not instruments:
+        return [
+            CheckResult(
+                name=name,
+                passed=True,
+                severity="warning",
+                message="No instruments in DB; skipping timezone check.",
+            )
+        ]
+
+    # Group instruments by timezone string
+    tz_to_instruments: dict[str, list[str]] = {}
+    for instr in instruments:
+        tz_to_instruments.setdefault(instr.timezone_str, []).append(
+            instr.instrument_pid
+        )
+
+    results = []
+    for tz_str, pids in tz_to_instruments.items():
+        instrument_list = ", ".join(pids)
+        try:
+            pytz.timezone(tz_str)
+        except pytz.exceptions.UnknownTimeZoneError:
+            results.append(
+                CheckResult(
+                    name=name,
+                    passed=False,
+                    severity="warning",
+                    message=(
+                        f"Unknown timezone '{tz_str}'. "
+                        f"Affected instruments: {instrument_list}. "
+                        "Use a valid IANA timezone (e.g., 'America/New_York')."
+                    ),
+                )
+            )
+        else:
+            results.append(
+                CheckResult(
+                    name=name,
+                    passed=True,
+                    severity="warning",
+                    message=(
+                        f"Timezone '{tz_str}' is valid "
+                        f"(instruments: {instrument_list})."
+                    ),
+                )
+            )
+
+    return results
+
+
+def _check_data_path_writable() -> CheckResult:
+    """Check that NX_DATA_PATH is writable by the current process."""
+    name = "data_path_writable"
+    data_path = Path(settings.NX_DATA_PATH)
+
+    if not os.access(data_path, os.W_OK):
+        return CheckResult(
+            name=name,
+            passed=False,
+            severity="error",
+            message=(
+                f"NX_DATA_PATH ({data_path}) is not writable. "
+                "Ensure the NexusLIMS process has write permission to this directory."
+            ),
+        )
+
+    return CheckResult(
+        name=name,
+        passed=True,
+        severity="error",
+        message=f"NX_DATA_PATH ({data_path}) is writable.",
+    )
+
+
+def _check_export_destinations() -> CheckResult:
+    """Check that at least one export destination is enabled and configured."""
+    name = "export_destinations"
+
+    try:
+        registry = get_registry()
+        enabled = registry.get_enabled_destinations()
+    except Exception as exc:
+        return CheckResult(
+            name=name,
+            passed=False,
+            severity="warning",
+            message=f"Could not discover export destinations: {exc}",
+        )
+
+    if not enabled:
+        return CheckResult(
+            name=name,
+            passed=False,
+            severity="warning",
+            message=(
+                "No export destinations are enabled. Built records will not be "
+                "uploaded anywhere. Configure at least one destination "
+                "(e.g., NX_CDCS_URL and NX_CDCS_TOKEN for CDCS)."
+            ),
+        )
+
+    failures = []
+    for dest in enabled:
+        try:
+            valid, err_msg = dest.validate_config()
+        except Exception as exc:
+            failures.append(f"{dest.name}: unexpected error: {exc}")
+            continue
+        if not valid:
+            failures.append(f"{dest.name}: {err_msg}")
+
+    if failures:
+        return CheckResult(
+            name=name,
+            passed=False,
+            severity="warning",
+            message=(
+                "Some export destinations have configuration issues "
+                "(transient network errors may be ignored): " + "; ".join(failures)
+            ),
+        )
+
+    dest_names = ", ".join(d.name for d in enabled)
+    return CheckResult(
+        name=name,
+        passed=True,
+        severity="warning",
+        message=f"Export destination(s) OK: {dest_names}.",
+    )
+
+
+def _check_nemo_harvester_config() -> list[CheckResult]:
+    """Check NEMO harvester config is present and each instance is reachable."""
+    name = "nemo_harvester_config"
+
+    try:
+        nemo_harvesters = settings.nemo_harvesters()
+    except Exception as exc:
+        return [
+            CheckResult(
+                name=name,
+                passed=False,
+                severity="warning",
+                message=f"Could not read NEMO harvester config: {exc}",
+            )
+        ]
+
+    if not nemo_harvesters:
+        # No harvesters configured — check if any instrument needs one
+        try:
+            with DBSession(get_engine()) as session:
+                nemo_instruments = session.exec(
+                    select(Instrument).where(Instrument.harvester == "nemo")
+                ).all()
+        except Exception as exc:
+            return [
+                CheckResult(
+                    name=name,
+                    passed=False,
+                    severity="warning",
+                    message=(
+                        f"No NEMO harvester config found, and could not query "
+                        f"instruments: {exc}"
+                    ),
+                )
+            ]
+
+        if not nemo_instruments:
+            return [
+                CheckResult(
+                    name=name,
+                    passed=True,
+                    severity="warning",
+                    message=(
+                        "No NEMO harvester configured and no instruments use NEMO "
+                        "harvester; skipping."
+                    ),
+                )
+            ]
+
+        pids = ", ".join(i.instrument_pid for i in nemo_instruments)
+        return [
+            CheckResult(
+                name=name,
+                passed=False,
+                severity="warning",
+                message=(
+                    f"No NEMO harvester configuration found "
+                    f"(NX_NEMO_ADDRESS_N / NX_NEMO_TOKEN_N not set), but the "
+                    f"following instruments use the NEMO harvester: {pids}. "
+                    "Set NX_NEMO_ADDRESS_1 and NX_NEMO_TOKEN_1 (and _2, _3, … "
+                    "for additional instances)."
+                ),
+            )
+        ]
+
+    # Harvesters are configured — probe each instance for reachability.
+    # Any HTTP response (including 4xx) counts as reachable; connection-level
+    # exceptions (refused, timeout, DNS) are retried with exponential backoff.
+    # After all retries are exhausted the check fails hard (severity="error").
+    probe_retries = 3  # 4 total attempts: delays of 1s, 2s, 4s between them
+
+    results = []
+    connectors = get_harvesters_enabled()
+    for i, connector in enumerate(connectors, start=1):
+        base_url = connector.config["base_url"]
+        token = connector.config["token"]
+        last_exc: Exception | None = None
+
+        for attempt in range(probe_retries + 1):
+            try:
+                resp = nexus_req(
+                    base_url,
+                    "GET",
+                    token_auth=token,
+                    retries=0,
+                    timeout=10,
+                )
+                # Any HTTP response means the server is up
+                results.append(
+                    CheckResult(
+                        name=name,
+                        passed=True,
+                        severity="error",
+                        message=(
+                            f"NEMO instance {i} ({base_url}) is reachable "
+                            f"(HTTP {resp.status_code})."
+                        ),
+                    )
+                )
+                last_exc = None
+                break
+            except Exception as exc:
+                last_exc = exc
+                if attempt < probe_retries:
+                    delay = 2**attempt  # 1s, 2s, 4s
+                    _logger.debug(
+                        "[preflight] NEMO instance %s unreachable (%s), "
+                        "retrying in %ss (attempt %s/%s)",
+                        i,
+                        exc,
+                        delay,
+                        attempt + 1,
+                        probe_retries + 1,
+                    )
+                    time.sleep(delay)
+
+        if last_exc is not None:
+            results.append(
+                CheckResult(
+                    name=name,
+                    passed=False,
+                    severity="error",
+                    message=(
+                        f"NEMO instance {i} ({base_url}) is not reachable after "
+                        f"{probe_retries + 1} attempts: {last_exc}. "
+                        "Harvesting will fail for all instruments using this instance."
+                    ),
+                )
+            )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_preflight_checks(*, dry_run: bool = False) -> list[CheckResult]:
+    """Run all preflight checks and return the results.
+
+    Checks are grouped into three categories:
+
+    * **Always-run single-result checks** — DB connectivity, table existence,
+      Alembic migration status, and instrument count.
+    * **Always-run multi-result checks** — per-instrument filestore paths,
+      harvester imports, timezone validity, and NEMO config presence.
+    * **Write-path checks (skipped in dry-run)** — data path writability and
+      export destination validation.
+
+    Every check is wrapped in ``try/except Exception`` so that an unexpected
+    failure in one check never prevents the remaining checks from running.
+
+    Parameters
+    ----------
+    dry_run
+        When ``True``, skip checks that require write access (checks 8 and 9).
+
+    Returns
+    -------
+    list[CheckResult]
+        All check results in the order they were executed.
+    """
+    results: list[CheckResult] = []
+
+    # --- Single-result checks (always run) ---
+    single_checks = [
+        (_check_db_reachable, "db_reachable", "error"),
+        (_check_db_tables, "db_tables", "error"),
+        (_check_alembic_migration, "alembic_migration", "error"),
+        (_check_instruments_exist, "instruments_exist", "warning"),
+    ]
+    for fn, fallback_name, fallback_severity in single_checks:
+        try:
+            results.append(fn())
+        except Exception as exc:
+            results.append(
+                CheckResult(
+                    name=fallback_name,
+                    passed=False,
+                    severity=fallback_severity,  # type: ignore[arg-type]
+                    message=f"Unexpected error in check: {exc}",
+                )
+            )
+
+    # --- Multi-result checks (always run) ---
+    multi_checks = [
+        (_check_instrument_filestore_paths, "instrument_filestore_paths", "warning"),
+        (_check_instrument_harvesters, "instrument_harvesters", "error"),
+        (_check_instrument_timezones, "instrument_timezones", "warning"),
+        (_check_nemo_harvester_config, "nemo_harvester_config", "warning"),
+    ]
+    for fn, fallback_name, fallback_severity in multi_checks:
+        try:
+            results.extend(fn())
+        except Exception as exc:
+            results.append(
+                CheckResult(
+                    name=fallback_name,
+                    passed=False,
+                    severity=fallback_severity,  # type: ignore[arg-type]
+                    message=f"Unexpected error in check: {exc}",
+                )
+            )
+
+    # --- Write-path checks (skipped in dry-run) ---
+    if not dry_run:
+        write_checks = [
+            (_check_data_path_writable, "data_path_writable", "error"),
+            (_check_export_destinations, "export_destinations", "warning"),
+        ]
+        for fn, fallback_name, fallback_severity in write_checks:
+            try:
+                results.append(fn())
+            except Exception as exc:
+                results.append(
+                    CheckResult(
+                        name=fallback_name,
+                        passed=False,
+                        severity=fallback_severity,  # type: ignore[arg-type]
+                        message=f"Unexpected error in check: {exc}",
+                    )
+                )
+
+    return results

--- a/nexusLIMS/cli/process_records.py
+++ b/nexusLIMS/cli/process_records.py
@@ -41,6 +41,7 @@ from filelock import FileLock, Timeout
 from rich.console import Console
 from rich.logging import RichHandler
 
+from nexusLIMS.builder.preflight import PreflightError
 from nexusLIMS.cli import _format_version
 
 # Heavy NexusLIMS imports are lazy-loaded inside functions to speed up --help/--version
@@ -371,6 +372,12 @@ def _run_with_lock(
                     dry_run=dry_run, dt_from=dt_from, dt_to=dt_to
                 )
                 logger.info("Record processing completed")
+            except PreflightError as e:
+                logger.error(  # noqa: TRY400
+                    "Preflight checks failed — record builder aborted"
+                )
+                for check in e.failed_checks:
+                    logger.error("  [%s] %s", check.name, check.message)  # noqa: TRY400
             except Exception:
                 logger.exception("Error during record processing")
 

--- a/nexusLIMS/exporters/destinations/cdcs.py
+++ b/nexusLIMS/exporters/destinations/cdcs.py
@@ -201,13 +201,14 @@ class CDCSDestination:
 
         return r.json()[0]["current"]
 
-    def _get_workspace_id(self) -> int:
+    def _get_workspace_id(self) -> int | None:
         """Get workspace ID from CDCS.
 
         Returns
         -------
-        int
-            Workspace ID
+        int or None
+            Workspace ID, or ``None`` if no workspaces are available (which
+            still means authentication succeeded).
 
         Raises
         ------
@@ -221,4 +222,5 @@ class CDCSDestination:
             msg = "Could not authenticate to CDCS"
             raise AuthenticationError(msg)
 
-        return r.json()[0]["id"]
+        workspaces = r.json()
+        return workspaces[0]["id"] if workspaces else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,12 +228,3 @@ typeCheckingMode = "basic"
 reportMissingImports = true
 reportMissingTypeStubs = false
 
-[tool.alembic]
-# Path to migration scripts (relative to pyproject.toml)
-script_location = "nexusLIMS/db/migrations"
-
-# Prepend current directory to sys.path for imports
-prepend_sys_path = ["."]
-
-# Use os.pathsep for cross-platform compatibility
-path_separator = "os"

--- a/tests/integration/test_preflight_integration.py
+++ b/tests/integration/test_preflight_integration.py
@@ -1,0 +1,261 @@
+"""Integration tests for preflight checks.
+
+These tests verify that the preflight checks interact correctly with live
+external services (NEMO, CDCS). They require Docker services to be running.
+
+Unlike the unit tests (which mock every external call), these tests:
+- Let the NEMO connectivity probe hit the real NEMO API.
+- Let the CDCS export destination check authenticate against real CDCS.
+- Run ``run_preflight_checks()`` end-to-end with the full service stack.
+
+Run with Docker services up:
+    pytest tests/integration/test_preflight_integration.py -v
+"""
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from sqlalchemy import text
+
+from nexusLIMS.builder.preflight import (
+    _ALEMBIC_INI_PATH,
+    PreflightError,
+    _check_export_destinations,
+    _check_nemo_harvester_config,
+    run_preflight_checks,
+)
+
+# ---------------------------------------------------------------------------
+# Session-scoped helper: seed alembic_version into the shared integration DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def integration_db_with_alembic(docker_services):
+    """Add an alembic_version row at the current head to the session DB.
+
+    The shared integration DB is created via SQLModel (no alembic migrations
+    are run), so it has all ORM tables but no alembic_version table.  This
+    fixture seeds that row so ``_check_alembic_migration`` reports PASS rather
+    than a hard error during full-run tests.
+    """
+    from nexusLIMS.db.engine import get_engine
+
+    cfg = Config(str(_ALEMBIC_INI_PATH))
+    cfg.set_main_option(
+        "script_location",
+        str(_ALEMBIC_INI_PATH.parent / "nexusLIMS" / "db" / "migrations"),
+    )
+    head = ScriptDirectory.from_config(cfg).get_current_head()
+
+    engine = get_engine()
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE IF NOT EXISTS alembic_version "
+                "(version_num VARCHAR(32) NOT NULL)"
+            )
+        )
+        conn.execute(text("DELETE FROM alembic_version"))
+        conn.execute(text(f"INSERT INTO alembic_version VALUES ('{head}')"))
+        conn.commit()
+
+    yield head
+
+    # Cleanup: drop so other tests that expect the table to be absent aren't affected
+    with engine.connect() as conn:
+        conn.execute(text("DROP TABLE IF EXISTS alembic_version"))
+        conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# NEMO connectivity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestPreflightNemoConnectivity:
+    """nemo_harvester_config check against a live NEMO service."""
+
+    def test_nemo_reachable_when_service_running(self, nemo_client):
+        """Connectivity probe passes when NEMO Docker service is up.
+
+        ``nemo_client`` sets NX_NEMO_ADDRESS_1 / NX_NEMO_TOKEN_1 and calls
+        refresh_settings(), so ``nemo_harvesters()`` returns one harvester.
+        The probe should receive any HTTP response and report PASS.
+        """
+        results = _check_nemo_harvester_config()
+
+        assert len(results) == 1
+        result = results[0]
+        assert result.passed is True
+        assert result.severity == "error"
+        assert "reachable" in result.message.lower()
+        assert "HTTP" in result.message
+
+    def test_nemo_unreachable_fails_hard(self, monkeypatch):
+        """Connectivity probe exhausts retries and returns severity=error.
+
+        The NEMO address is unreachable (nothing listening on the port).
+        A connection-refused error on localhost is immediate so the test
+        completes in roughly 7 s (3 sleeps: 1 + 2 + 4 s).
+        """
+        from nexusLIMS.config import refresh_settings
+
+        monkeypatch.setenv("NX_NEMO_ADDRESS_1", "http://localhost:19999/api/")
+        monkeypatch.setenv("NX_NEMO_TOKEN_1", "irrelevant")
+        refresh_settings()
+
+        results = _check_nemo_harvester_config()
+
+        assert len(results) == 1
+        result = results[0]
+        assert result.passed is False
+        assert result.severity == "error"
+        assert "not reachable after 4 attempts" in result.message
+
+    def test_nemo_http_error_still_counts_as_reachable(self, nemo_url, monkeypatch):
+        """An HTTP 4xx/5xx from NEMO counts as reachable (server is up).
+
+        Using the correct NEMO base URL but a deliberately wrong token should
+        still return an HTTP response (likely 401/403), which the check treats
+        as "server is reachable".
+        """
+        from nexusLIMS.config import refresh_settings
+
+        monkeypatch.setenv("NX_NEMO_ADDRESS_1", f"{nemo_url}/api/")
+        monkeypatch.setenv("NX_NEMO_TOKEN_1", "bad-token-that-does-not-exist")
+        refresh_settings()
+
+        results = _check_nemo_harvester_config()
+
+        assert len(results) == 1
+        result = results[0]
+        assert result.passed is True, (
+            f"Expected PASS (HTTP error = server up), got: {result.message}"
+        )
+        assert "HTTP" in result.message
+
+
+# ---------------------------------------------------------------------------
+# CDCS export destinations
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestPreflightExportDestinations:
+    """export_destinations check against a live CDCS service."""
+
+    def test_cdcs_passes_with_valid_credentials(self, cdcs_client, monkeypatch):
+        """CDCS destination passes when credentials are valid.
+
+        ``cdcs_client`` sets NX_CDCS_URL and NX_CDCS_TOKEN to the test
+        instance values and calls refresh_settings().
+
+        In NX_TEST_MODE the eLabFTW settings have non-None defaults, so
+        eLabFTW is always enabled alongside CDCS.  We disable it here so the
+        check is purely about CDCS.
+        """
+        from nexusLIMS.exporters.destinations.elabftw import ELabFTWDestination
+
+        monkeypatch.setattr(ELabFTWDestination, "enabled", property(lambda _: False))
+
+        result = _check_export_destinations()
+
+        assert result.passed is True, f"Expected CDCS to pass; got: {result.message}"
+        assert result.severity == "warning"
+
+    def test_cdcs_warns_with_invalid_token(self, cdcs_url, monkeypatch):
+        """CDCS destination warns (not errors) when the token is invalid.
+
+        The check uses severity="warning" for destination config issues because
+        a transient network error should not abort a run.
+        """
+        from nexusLIMS.config import refresh_settings
+
+        monkeypatch.setenv("NX_CDCS_URL", cdcs_url)
+        monkeypatch.setenv("NX_CDCS_TOKEN", "this-token-is-definitely-invalid-xyz")
+        refresh_settings()
+
+        result = _check_export_destinations()
+
+        assert result.passed is False
+        assert result.severity == "warning"
+        msg = result.message.lower()
+        assert "cdcs" in msg or "authentication" in msg
+
+    def test_cdcs_warns_when_no_destinations_configured(self, monkeypatch):
+        """export_destinations warns when all destination ``enabled`` props are False.
+
+        NX_TEST_MODE provides default values for NX_CDCS_URL and NX_CDCS_TOKEN,
+        so env-var deletion alone can't produce "no destinations".  We monkeypatch
+        the ``enabled`` property on both destination classes to force the
+        no-destinations code path.
+        """
+        from nexusLIMS.exporters.destinations.cdcs import CDCSDestination
+        from nexusLIMS.exporters.destinations.elabftw import ELabFTWDestination
+
+        monkeypatch.setattr(CDCSDestination, "enabled", property(lambda _: False))
+        monkeypatch.setattr(ELabFTWDestination, "enabled", property(lambda _: False))
+
+        result = _check_export_destinations()
+
+        assert result.passed is False
+        assert result.severity == "warning"
+        assert "no export destinations" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# Full run_preflight_checks() with all services live
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestPreflightFullRun:
+    """End-to-end tests that call run_preflight_checks() with real services."""
+
+    def test_no_error_checks_fail_with_full_stack(
+        self,
+        nemo_client,
+        cdcs_client,
+        integration_db_with_alembic,
+    ):
+        """With NEMO, CDCS, and a properly migrated DB, no error-severity check fails.
+
+        Expected result: all checks pass or produce warnings only.  Warnings
+        (instruments_exist, nemo_harvester_config, etc.) are fine because the
+        test DB is empty.  There should be zero error-severity failures.
+        """
+        results = run_preflight_checks(dry_run=True)
+
+        failed_errors = [r for r in results if not r.passed and r.severity == "error"]
+        assert failed_errors == [], "Unexpected error-severity failures: " + str(
+            [(r.name, r.message) for r in failed_errors]
+        )
+
+    def test_process_new_records_does_not_abort_on_valid_config(
+        self,
+        nemo_client,
+        cdcs_client,
+        integration_db_with_alembic,
+    ):
+        """process_new_records(dry_run=True) must not raise PreflightError.
+
+        With all services configured correctly, the preflight gate should pass
+        and execution should continue (finding no sessions to build in the
+        empty test DB is fine).
+        """
+        from nexusLIMS.builder import record_builder
+
+        try:
+            record_builder.process_new_records(dry_run=True)
+        except PreflightError as e:
+            pytest.fail(
+                "process_new_records raised PreflightError unexpectedly. "
+                f"Failed checks: {[(c.name, c.message) for c in e.failed_checks]}"
+            )
+        except Exception:
+            # Post-preflight failures (no sessions, gfind errors, missing files,
+            # etc.) are acceptable — the preflight gate passed, which is what
+            # this test verifies.
+            pass

--- a/tests/unit/test_record_builder/conftest.py
+++ b/tests/unit/test_record_builder/conftest.py
@@ -5,8 +5,25 @@ from datetime import datetime as dt
 import pytest
 
 from nexusLIMS.builder import record_builder
+from nexusLIMS.builder.preflight import CheckResult
 from nexusLIMS.harvesters.reservation_event import ReservationEvent
 from tests.unit.test_instrument_factory import make_titan_tem
+
+
+@pytest.fixture
+def mock_preflight_pass(monkeypatch):
+    """Mock run_preflight_checks to return all-passing results.
+
+    Unit tests for process_new_records() test record-building logic, not
+    preflight checks.  This fixture bypasses preflight so the unit tests
+    don't require a fully-migrated DB or live NEMO credentials.
+    """
+    monkeypatch.setattr(
+        "nexusLIMS.builder.record_builder.run_preflight_checks",
+        lambda **_kwargs: [
+            CheckResult("all_checks", passed=True, severity="error", message="mocked")
+        ],
+    )
 
 
 @pytest.fixture(name="mock_nemo_reservation")

--- a/tests/unit/test_record_builder/test_preflight.py
+++ b/tests/unit/test_record_builder/test_preflight.py
@@ -1,0 +1,1267 @@
+# ruff: noqa: FBT003
+"""Unit tests for nexusLIMS.builder.preflight module."""
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nexusLIMS.builder.preflight import (
+    CheckResult,
+    PreflightError,
+    _check_alembic_migration,
+    _check_data_path_writable,
+    _check_db_reachable,
+    _check_db_tables,
+    _check_export_destinations,
+    _check_instrument_filestore_paths,
+    _check_instrument_harvesters,
+    _check_instrument_timezones,
+    _check_instruments_exist,
+    _check_nemo_harvester_config,
+    run_preflight_checks,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_minimal_db(path: Path) -> None:
+    """Create an empty SQLite DB with no NexusLIMS tables."""
+    conn = sqlite3.connect(str(path))
+    conn.close()
+
+
+def _make_full_db(path: Path) -> None:
+    """Create a SQLite DB with all NexusLIMS tables (no migration tracking)."""
+    from sqlmodel import SQLModel, create_engine
+
+    # Ensure all model classes are registered in SQLModel.metadata
+    from nexusLIMS.db.models import (  # noqa: F401
+        ExternalUserIdentifier,
+        Instrument,
+        SessionLog,
+        UploadLog,
+    )
+
+    engine = create_engine(f"sqlite:///{path}")
+    SQLModel.metadata.create_all(engine)
+    engine.dispose()
+
+
+def _get_engine_for(path: Path):
+    """Return a fresh SQLAlchemy engine for the given DB path."""
+    from sqlmodel import create_engine
+
+    return create_engine(f"sqlite:///{path}", connect_args={"check_same_thread": False})
+
+
+# ---------------------------------------------------------------------------
+# CheckResult and PreflightError
+# ---------------------------------------------------------------------------
+
+
+class TestCheckResult:
+    """Tests for the CheckResult dataclass."""
+
+    def test_fields(self):
+        r = CheckResult(
+            name="test", passed=True, severity="warning", message="all good"
+        )
+        assert r.name == "test"
+        assert r.passed is True
+        assert r.severity == "warning"
+        assert r.message == "all good"
+
+
+class TestPreflightError:
+    """Tests for the PreflightError exception."""
+
+    def test_message_lists_check_names(self):
+        checks = [
+            CheckResult(
+                name="db_reachable", passed=False, severity="error", message="x"
+            ),
+            CheckResult(name="db_tables", passed=False, severity="error", message="y"),
+        ]
+        err = PreflightError(checks)
+        assert "db_reachable" in str(err)
+        assert "db_tables" in str(err)
+        assert err.failed_checks is checks
+
+
+# ---------------------------------------------------------------------------
+# _check_db_reachable
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDbReachable:
+    """Tests for _check_db_reachable."""
+
+    def test_pass_when_db_exists(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "test.db"
+        _make_full_db(db_path)
+        engine = _get_engine_for(db_path)
+
+        monkeypatch.setattr("nexusLIMS.builder.preflight.settings.NX_DB_PATH", db_path)
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            result = _check_db_reachable()
+
+        assert result.passed is True
+        assert result.name == "db_reachable"
+
+    def test_fail_when_file_missing(self, tmp_path, monkeypatch):
+        missing = tmp_path / "no_such.db"
+        monkeypatch.setattr("nexusLIMS.builder.preflight.settings.NX_DB_PATH", missing)
+        result = _check_db_reachable()
+
+        assert result.passed is False
+        assert result.severity == "error"
+        assert "not found" in result.message.lower() or "not" in result.message.lower()
+
+    def test_fail_when_connection_raises(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "bad.db"
+        db_path.write_bytes(b"not a sqlite database content")
+        monkeypatch.setattr("nexusLIMS.builder.preflight.settings.NX_DB_PATH", db_path)
+
+        bad_engine = MagicMock()
+        bad_engine.__enter__ = MagicMock(side_effect=Exception("connection refused"))
+
+        with patch(
+            "nexusLIMS.builder.preflight.get_engine",
+            side_effect=Exception("cannot connect"),
+        ):
+            result = _check_db_reachable()
+
+        assert result.passed is False
+        assert result.severity == "error"
+
+
+# ---------------------------------------------------------------------------
+# _check_db_tables
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDbTables:
+    """Tests for _check_db_tables."""
+
+    def test_pass_when_all_tables_present(self, tmp_path):
+        db_path = tmp_path / "full.db"
+        _make_full_db(db_path)
+        engine = _get_engine_for(db_path)
+
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            result = _check_db_tables()
+
+        assert result.passed is True
+        assert result.name == "db_tables"
+
+    def test_fail_when_table_missing(self, tmp_path):
+        db_path = tmp_path / "empty.db"
+        _make_minimal_db(db_path)  # No NexusLIMS tables
+        engine = _get_engine_for(db_path)
+
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            result = _check_db_tables()
+
+        assert result.passed is False
+        assert result.severity == "error"
+        assert "missing" in result.message.lower()
+
+    def test_fail_when_engine_raises(self):
+        with patch(
+            "nexusLIMS.builder.preflight.get_engine",
+            side_effect=Exception("engine error"),
+        ):
+            result = _check_db_tables()
+
+        assert result.passed is False
+        assert result.severity == "error"
+        assert "could not query" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# _check_alembic_migration
+# ---------------------------------------------------------------------------
+
+
+class TestCheckAlembicMigration:
+    """Tests for _check_alembic_migration."""
+
+    def test_pass_when_at_head(self, tmp_path):
+        db_path = tmp_path / "alembic.db"
+        _make_full_db(db_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE alembic_version (version_num TEXT PRIMARY KEY)")
+        conn.execute("INSERT INTO alembic_version VALUES ('v2_5_0b')")
+        conn.commit()
+        conn.close()
+
+        engine = _get_engine_for(db_path)
+
+        mock_script = MagicMock()
+        mock_script.get_current_head.return_value = "v2_5_0b"
+
+        with (
+            patch("nexusLIMS.builder.preflight.get_engine", return_value=engine),
+            patch("nexusLIMS.builder.preflight.ScriptDirectory") as mock_sd_class,
+        ):
+            mock_sd_class.from_config.return_value = mock_script
+            # Also patch Config so we don't need alembic.ini on disk
+            with patch("nexusLIMS.builder.preflight.Config"):
+                result = _check_alembic_migration()
+
+        assert result.passed is True
+        assert "up to date" in result.message
+
+    def test_fail_hard_when_behind(self, tmp_path):
+        db_path = tmp_path / "behind.db"
+        _make_full_db(db_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("CREATE TABLE alembic_version (version_num TEXT PRIMARY KEY)")
+        conn.execute("INSERT INTO alembic_version VALUES ('v1_4_3')")
+        conn.commit()
+        conn.close()
+
+        engine = _get_engine_for(db_path)
+
+        mock_script = MagicMock()
+        mock_script.get_current_head.return_value = "v2_5_0b"
+
+        with (
+            patch("nexusLIMS.builder.preflight.get_engine", return_value=engine),
+            patch("nexusLIMS.builder.preflight.ScriptDirectory") as mock_sd_class,
+            patch("nexusLIMS.builder.preflight.Config"),
+        ):
+            mock_sd_class.from_config.return_value = mock_script
+            result = _check_alembic_migration()
+
+        assert result.passed is False
+        assert result.severity == "error"
+        assert "out of date" in result.message
+
+    def test_pass_when_head_rev_is_none(self):
+        """When no Alembic revisions exist, check passes (nothing to compare)."""
+        mock_script = MagicMock()
+        mock_script.get_current_head.return_value = None
+
+        with (
+            patch("nexusLIMS.builder.preflight.ScriptDirectory") as mock_sd_class,
+            patch("nexusLIMS.builder.preflight.Config"),
+        ):
+            mock_sd_class.from_config.return_value = mock_script
+            result = _check_alembic_migration()
+
+        assert result.passed is True
+        assert "no alembic revisions" in result.message.lower()
+
+    def test_fail_when_config_raises(self):
+        """Exception in Config/ScriptDirectory returns error result."""
+        with patch(
+            "nexusLIMS.builder.preflight.Config",
+            side_effect=Exception("ini not found"),
+        ):
+            result = _check_alembic_migration()
+
+        assert result.passed is False
+        assert result.severity == "error"
+        assert "could not determine" in result.message.lower()
+
+    def test_fail_when_alembic_version_query_raises(self, tmp_path):
+        """Exception querying alembic_version returns error result."""
+        mock_script = MagicMock()
+        mock_script.get_current_head.return_value = "v2_5_0b"
+
+        with (
+            patch(
+                "nexusLIMS.builder.preflight.get_engine",
+                side_effect=Exception("db error"),
+            ),
+            patch("nexusLIMS.builder.preflight.ScriptDirectory") as mock_sd_class,
+            patch("nexusLIMS.builder.preflight.Config"),
+        ):
+            mock_sd_class.from_config.return_value = mock_script
+            result = _check_alembic_migration()
+
+        assert result.passed is False
+        assert result.severity == "error"
+        assert "could not query alembic_version" in result.message.lower()
+
+    def test_fail_hard_when_no_alembic_version_table(self, tmp_path):
+        db_path = tmp_path / "no_alembic.db"
+        _make_full_db(db_path)
+        engine = _get_engine_for(db_path)
+
+        mock_script = MagicMock()
+        mock_script.get_current_head.return_value = "v2_5_0b"
+
+        with (
+            patch("nexusLIMS.builder.preflight.get_engine", return_value=engine),
+            patch("nexusLIMS.builder.preflight.ScriptDirectory") as mock_sd_class,
+            patch("nexusLIMS.builder.preflight.Config"),
+        ):
+            mock_sd_class.from_config.return_value = mock_script
+            result = _check_alembic_migration()
+
+        assert result.passed is False
+        assert result.severity == "error"
+        assert "alembic_version" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# _check_instruments_exist
+# ---------------------------------------------------------------------------
+
+
+class TestCheckInstrumentsExist:
+    """Tests for _check_instruments_exist."""
+
+    def test_pass_when_instruments_present(self, tmp_path):
+        db_path = tmp_path / "with_instruments.db"
+        _make_full_db(db_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO instruments "
+            "(instrument_pid, api_url, calendar_url, location, display_name, "
+            "property_tag, filestore_path, harvester, timezone) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "TEST-1",
+                "http://example.com/api/tools/?id=1",
+                "http://example.com/cal/",
+                "Room 1",
+                "Test Instrument",
+                "TAG-001",
+                "./data",
+                "nemo",
+                "America/New_York",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        engine = _get_engine_for(db_path)
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            result = _check_instruments_exist()
+
+        assert result.passed is True
+
+    def test_warn_when_empty(self, tmp_path):
+        db_path = tmp_path / "empty_instruments.db"
+        _make_full_db(db_path)
+        engine = _get_engine_for(db_path)
+
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            result = _check_instruments_exist()
+
+        assert result.passed is False
+        assert result.severity == "warning"
+
+    def test_warn_when_engine_raises(self):
+        with patch(
+            "nexusLIMS.builder.preflight.get_engine",
+            side_effect=Exception("engine error"),
+        ):
+            result = _check_instruments_exist()
+
+        assert result.passed is False
+        assert result.severity == "warning"
+        assert "could not query" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# _check_instrument_filestore_paths
+# ---------------------------------------------------------------------------
+
+
+class TestCheckInstrumentFilestorePaths:
+    """Tests for _check_instrument_filestore_paths."""
+
+    def _make_db_with_instrument(self, path: Path, filestore: str) -> None:
+        _make_full_db(path)
+        conn = sqlite3.connect(str(path))
+        conn.execute(
+            "INSERT INTO instruments "
+            "(instrument_pid, api_url, calendar_url, location, display_name, "
+            "property_tag, filestore_path, harvester, timezone) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "TEST-1",
+                "http://example.com/api/tools/?id=1",
+                "http://example.com/cal/",
+                "Room 1",
+                "Test Instrument",
+                "TAG-001",
+                filestore,
+                "nemo",
+                "America/New_York",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_pass_when_paths_exist(self, tmp_path, monkeypatch):
+        instr_root = tmp_path / "instruments"
+        filestore = instr_root / "MyScope"
+        filestore.mkdir(parents=True)
+
+        db_path = tmp_path / "paths.db"
+        self._make_db_with_instrument(db_path, "MyScope")
+
+        engine = _get_engine_for(db_path)
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.NX_INSTRUMENT_DATA_PATH",
+            instr_root,
+        )
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            results = _check_instrument_filestore_paths()
+
+        assert all(r.passed for r in results)
+
+    def test_warn_when_path_missing(self, tmp_path, monkeypatch):
+        instr_root = tmp_path / "instruments"
+        instr_root.mkdir()  # root exists but no subdirectory
+
+        db_path = tmp_path / "paths_missing.db"
+        self._make_db_with_instrument(db_path, "NoSuchScope")
+
+        engine = _get_engine_for(db_path)
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.NX_INSTRUMENT_DATA_PATH",
+            instr_root,
+        )
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            results = _check_instrument_filestore_paths()
+
+        failed = [r for r in results if not r.passed]
+        assert len(failed) >= 1
+        assert all(r.severity == "warning" for r in failed)
+
+    def test_warn_when_base_path_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.NX_INSTRUMENT_DATA_PATH",
+            tmp_path / "nonexistent_base",
+        )
+        results = _check_instrument_filestore_paths()
+
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert results[0].severity == "warning"
+
+    def test_warn_when_engine_raises(self, tmp_path, monkeypatch):
+        """Base path exists but instruments query fails."""
+        instr_root = tmp_path / "instruments"
+        instr_root.mkdir()
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.NX_INSTRUMENT_DATA_PATH",
+            instr_root,
+        )
+        with patch(
+            "nexusLIMS.builder.preflight.get_engine",
+            side_effect=Exception("db error"),
+        ):
+            results = _check_instrument_filestore_paths()
+
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert results[0].severity == "warning"
+        assert "could not query" in results[0].message.lower()
+
+    def test_pass_when_no_instruments(self, tmp_path, monkeypatch):
+        """Base path exists and DB has no instruments — skip with PASS."""
+        instr_root = tmp_path / "instruments"
+        instr_root.mkdir()
+        db_path = tmp_path / "empty.db"
+        _make_full_db(db_path)
+        engine = _get_engine_for(db_path)
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.NX_INSTRUMENT_DATA_PATH",
+            instr_root,
+        )
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            results = _check_instrument_filestore_paths()
+
+        assert len(results) == 1
+        assert results[0].passed is True
+        assert "skipping" in results[0].message.lower()
+
+
+# ---------------------------------------------------------------------------
+# _check_instrument_harvesters
+# ---------------------------------------------------------------------------
+
+
+class TestCheckInstrumentHarvesters:
+    """Tests for _check_instrument_harvesters."""
+
+    def _make_db_with_harvester(self, path: Path, harvester: str) -> None:
+        _make_full_db(path)
+        conn = sqlite3.connect(str(path))
+        conn.execute(
+            "INSERT INTO instruments "
+            "(instrument_pid, api_url, calendar_url, location, display_name, "
+            "property_tag, filestore_path, harvester, timezone) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "TEST-1",
+                "http://example.com/api/tools/?id=1",
+                "http://example.com/cal/",
+                "Room 1",
+                "Test Instrument",
+                "TAG-001",
+                "./data",
+                harvester,
+                "America/New_York",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_pass_for_valid_nemo_harvester(self, tmp_path):
+        db_path = tmp_path / "nemo.db"
+        self._make_db_with_harvester(db_path, "nemo")
+        engine = _get_engine_for(db_path)
+
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            results = _check_instrument_harvesters()
+
+        assert all(r.passed for r in results)
+
+    def test_fail_when_module_not_importable(self, tmp_path):
+        db_path = tmp_path / "bad_harvester.db"
+        self._make_db_with_harvester(db_path, "nonexistent_harvester")
+        engine = _get_engine_for(db_path)
+
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            results = _check_instrument_harvesters()
+
+        failed = [r for r in results if not r.passed]
+        assert len(failed) >= 1
+        assert all(r.severity == "error" for r in failed)
+
+    def test_fail_when_engine_raises(self):
+        with patch(
+            "nexusLIMS.builder.preflight.get_engine",
+            side_effect=Exception("db error"),
+        ):
+            results = _check_instrument_harvesters()
+
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert results[0].severity == "error"
+        assert "could not query" in results[0].message.lower()
+
+    def test_pass_when_no_instruments(self, tmp_path):
+        """DB has no instruments — skip with PASS."""
+        db_path = tmp_path / "empty.db"
+        _make_full_db(db_path)
+        engine = _get_engine_for(db_path)
+
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            results = _check_instrument_harvesters()
+
+        assert len(results) == 1
+        assert results[0].passed is True
+        assert "skipping" in results[0].message.lower()
+
+    def test_fail_when_function_missing(self, tmp_path):
+        db_path = tmp_path / "incomplete_harvester.db"
+        self._make_db_with_harvester(db_path, "fake_harvester")
+        engine = _get_engine_for(db_path)
+
+        # Module exists but lacks res_event_from_session
+        fake_module = MagicMock(spec=[])  # no attributes
+
+        with (
+            patch("nexusLIMS.builder.preflight.get_engine", return_value=engine),
+            patch(
+                "nexusLIMS.builder.preflight.import_module", return_value=fake_module
+            ),
+        ):
+            results = _check_instrument_harvesters()
+
+        failed = [r for r in results if not r.passed]
+        assert len(failed) >= 1
+        assert any("res_event_from_session" in r.message for r in failed)
+
+
+# ---------------------------------------------------------------------------
+# _check_instrument_timezones
+# ---------------------------------------------------------------------------
+
+
+class TestCheckInstrumentTimezones:
+    """Tests for _check_instrument_timezones."""
+
+    def _make_db_with_tz(self, path: Path, tz: str) -> None:
+        _make_full_db(path)
+        conn = sqlite3.connect(str(path))
+        conn.execute(
+            "INSERT INTO instruments "
+            "(instrument_pid, api_url, calendar_url, location, display_name, "
+            "property_tag, filestore_path, harvester, timezone) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "TEST-1",
+                "http://example.com/api/tools/?id=1",
+                "http://example.com/cal/",
+                "Room 1",
+                "Test Instrument",
+                "TAG-001",
+                "./data",
+                "nemo",
+                tz,
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_pass_for_valid_timezone(self, tmp_path):
+        db_path = tmp_path / "valid_tz.db"
+        self._make_db_with_tz(db_path, "America/New_York")
+        engine = _get_engine_for(db_path)
+
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            results = _check_instrument_timezones()
+
+        assert all(r.passed for r in results)
+
+    def test_warn_for_invalid_timezone(self, tmp_path):
+        db_path = tmp_path / "invalid_tz.db"
+        self._make_db_with_tz(db_path, "NotA/RealTimezone")
+        engine = _get_engine_for(db_path)
+
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            results = _check_instrument_timezones()
+
+        failed = [r for r in results if not r.passed]
+        assert len(failed) >= 1
+        assert all(r.severity == "warning" for r in failed)
+
+    def test_warn_when_engine_raises(self):
+        with patch(
+            "nexusLIMS.builder.preflight.get_engine",
+            side_effect=Exception("db error"),
+        ):
+            results = _check_instrument_timezones()
+
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert results[0].severity == "warning"
+        assert "could not query" in results[0].message.lower()
+
+    def test_pass_when_no_instruments(self, tmp_path):
+        """DB has no instruments — skip with PASS."""
+        db_path = tmp_path / "empty.db"
+        _make_full_db(db_path)
+        engine = _get_engine_for(db_path)
+
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            results = _check_instrument_timezones()
+
+        assert len(results) == 1
+        assert results[0].passed is True
+        assert "skipping" in results[0].message.lower()
+
+
+# ---------------------------------------------------------------------------
+# _check_data_path_writable
+# ---------------------------------------------------------------------------
+
+
+class TestCheckDataPathWritable:
+    """Tests for _check_data_path_writable."""
+
+    def test_pass_when_writable(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.NX_DATA_PATH", tmp_path
+        )
+        with patch("nexusLIMS.builder.preflight.os.access", return_value=True):
+            result = _check_data_path_writable()
+
+        assert result.passed is True
+        assert result.name == "data_path_writable"
+
+    def test_fail_when_not_writable(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.NX_DATA_PATH", tmp_path
+        )
+        with patch("nexusLIMS.builder.preflight.os.access", return_value=False):
+            result = _check_data_path_writable()
+
+        assert result.passed is False
+        assert result.severity == "error"
+        assert "not writable" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# _check_export_destinations
+# ---------------------------------------------------------------------------
+
+
+class TestCheckExportDestinations:
+    """Tests for _check_export_destinations."""
+
+    def test_pass_when_all_destinations_valid(self):
+        dest = MagicMock()
+        dest.name = "cdcs"
+        dest.validate_config.return_value = (True, None)
+
+        mock_registry = MagicMock()
+        mock_registry.get_enabled_destinations.return_value = [dest]
+
+        with patch(
+            "nexusLIMS.builder.preflight.get_registry", return_value=mock_registry
+        ):
+            result = _check_export_destinations()
+
+        assert result.passed is True
+        assert "cdcs" in result.message
+
+    def test_warn_when_destination_config_invalid(self):
+        dest = MagicMock()
+        dest.name = "cdcs"
+        dest.validate_config.return_value = (False, "API key missing")
+
+        mock_registry = MagicMock()
+        mock_registry.get_enabled_destinations.return_value = [dest]
+
+        with patch(
+            "nexusLIMS.builder.preflight.get_registry", return_value=mock_registry
+        ):
+            result = _check_export_destinations()
+
+        assert result.passed is False
+        assert result.severity == "warning"
+
+    def test_warn_when_no_destinations_enabled(self):
+        mock_registry = MagicMock()
+        mock_registry.get_enabled_destinations.return_value = []
+
+        with patch(
+            "nexusLIMS.builder.preflight.get_registry", return_value=mock_registry
+        ):
+            result = _check_export_destinations()
+
+        assert result.passed is False
+        assert result.severity == "warning"
+        assert "no export destinations" in result.message.lower()
+
+    def test_warn_when_get_registry_raises(self):
+        with patch(
+            "nexusLIMS.builder.preflight.get_registry",
+            side_effect=Exception("registry error"),
+        ):
+            result = _check_export_destinations()
+
+        assert result.passed is False
+        assert result.severity == "warning"
+        assert "could not discover" in result.message.lower()
+
+    def test_warn_when_validate_config_raises(self):
+        dest = MagicMock()
+        dest.name = "cdcs"
+        dest.validate_config.side_effect = RuntimeError("unexpected crash")
+
+        mock_registry = MagicMock()
+        mock_registry.get_enabled_destinations.return_value = [dest]
+
+        with patch(
+            "nexusLIMS.builder.preflight.get_registry", return_value=mock_registry
+        ):
+            result = _check_export_destinations()
+
+        assert result.passed is False
+        assert result.severity == "warning"
+        assert "unexpected error" in result.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# _check_nemo_harvester_config
+# ---------------------------------------------------------------------------
+
+
+class TestCheckNemoHarvesterConfig:
+    """Tests for _check_nemo_harvester_config."""
+
+    def _mock_connector(self, base_url="http://nemo.example.com/api/"):
+        connector = MagicMock()
+        connector.config = {"base_url": base_url, "token": "fake-token"}
+        return connector
+
+    def test_pass_when_harvesters_reachable(self, monkeypatch):
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.nemo_harvesters",
+            lambda: {1: MagicMock()},
+        )
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+
+        with (
+            patch(
+                "nexusLIMS.builder.preflight.get_harvesters_enabled",
+                return_value=[self._mock_connector()],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight.nexus_req",
+                return_value=mock_resp,
+            ),
+        ):
+            results = _check_nemo_harvester_config()
+
+        assert all(r.passed for r in results)
+        assert any("reachable" in r.message for r in results)
+        assert all(r.severity == "error" for r in results)
+
+    def test_fail_hard_when_harvesters_unreachable_after_retries(self, monkeypatch):
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.nemo_harvesters",
+            lambda: {1: MagicMock()},
+        )
+
+        with (
+            patch(
+                "nexusLIMS.builder.preflight.get_harvesters_enabled",
+                return_value=[self._mock_connector()],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight.nexus_req",
+                side_effect=Exception("Connection refused"),
+            ),
+            patch("nexusLIMS.builder.preflight.time.sleep"),
+        ):
+            results = _check_nemo_harvester_config()
+
+        failed = [r for r in results if not r.passed]
+        assert len(failed) >= 1
+        assert all(r.severity == "error" for r in failed)
+        assert any("not reachable after 4 attempts" in r.message for r in failed)
+
+    def test_retries_sleep_with_backoff(self, monkeypatch):
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.nemo_harvesters",
+            lambda: {1: MagicMock()},
+        )
+
+        with (
+            patch(
+                "nexusLIMS.builder.preflight.get_harvesters_enabled",
+                return_value=[self._mock_connector()],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight.nexus_req",
+                side_effect=Exception("timeout"),
+            ),
+            patch("nexusLIMS.builder.preflight.time.sleep") as mock_sleep,
+        ):
+            _check_nemo_harvester_config()
+
+        # Expect three sleep calls with delays 1, 2, 4
+        assert mock_sleep.call_count == 3
+        assert [c.args[0] for c in mock_sleep.call_args_list] == [1, 2, 4]
+
+    def test_warn_when_no_config_but_nemo_instruments(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "nemo_instruments.db"
+        _make_full_db(db_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO instruments "
+            "(instrument_pid, api_url, calendar_url, location, display_name, "
+            "property_tag, filestore_path, harvester, timezone) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "TEST-NEMO",
+                "http://example.com/api/tools/?id=1",
+                "http://example.com/cal/",
+                "Room 1",
+                "Test Instrument",
+                "TAG-001",
+                "./data",
+                "nemo",
+                "America/New_York",
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        engine = _get_engine_for(db_path)
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.nemo_harvesters", dict
+        )
+
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            results = _check_nemo_harvester_config()
+
+        failed = [r for r in results if not r.passed]
+        assert len(failed) >= 1
+        assert "TEST-NEMO" in failed[0].message
+
+    def test_warn_when_nemo_harvesters_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.nemo_harvesters",
+            MagicMock(side_effect=Exception("config error")),
+        )
+        results = _check_nemo_harvester_config()
+
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert results[0].severity == "warning"
+        assert "could not read" in results[0].message.lower()
+
+    def test_warn_when_no_harvesters_and_engine_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.nemo_harvesters", dict
+        )
+        with patch(
+            "nexusLIMS.builder.preflight.get_engine",
+            side_effect=Exception("db error"),
+        ):
+            results = _check_nemo_harvester_config()
+
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert results[0].severity == "warning"
+        assert "could not query" in results[0].message.lower()
+
+    def test_pass_when_no_config_and_no_nemo_instruments(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "no_nemo.db"
+        _make_full_db(db_path)  # No instruments inserted
+        engine = _get_engine_for(db_path)
+
+        monkeypatch.setattr(
+            "nexusLIMS.builder.preflight.settings.nemo_harvesters", dict
+        )
+
+        with patch("nexusLIMS.builder.preflight.get_engine", return_value=engine):
+            results = _check_nemo_harvester_config()
+
+        assert all(r.passed for r in results)
+
+
+# ---------------------------------------------------------------------------
+# run_preflight_checks
+# ---------------------------------------------------------------------------
+
+
+class TestRunPreflightChecks:
+    """Tests for the main run_preflight_checks() function."""
+
+    def test_dry_run_skips_write_checks(self):
+        """In dry-run mode, data_path_writable and export_destinations are absent."""
+        with (
+            patch(
+                "nexusLIMS.builder.preflight._check_db_reachable",
+                return_value=CheckResult("db_reachable", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_db_tables",
+                return_value=CheckResult("db_tables", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_alembic_migration",
+                return_value=CheckResult("alembic_migration", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instruments_exist",
+                return_value=CheckResult("instruments_exist", True, "warning", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_filestore_paths",
+                return_value=[
+                    CheckResult("instrument_filestore_paths", True, "warning", "ok")
+                ],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_harvesters",
+                return_value=[
+                    CheckResult("instrument_harvesters", True, "error", "ok")
+                ],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_timezones",
+                return_value=[
+                    CheckResult("instrument_timezones", True, "warning", "ok")
+                ],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_nemo_harvester_config",
+                return_value=[
+                    CheckResult("nemo_harvester_config", True, "warning", "ok")
+                ],
+            ),
+        ):
+            results = run_preflight_checks(dry_run=True)
+
+        names = {r.name for r in results}
+        assert "data_path_writable" not in names
+        assert "export_destinations" not in names
+
+    def test_non_dry_run_includes_write_checks(self):
+        """In normal mode, data_path_writable and export_destinations are included."""
+        with (
+            patch(
+                "nexusLIMS.builder.preflight._check_db_reachable",
+                return_value=CheckResult("db_reachable", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_db_tables",
+                return_value=CheckResult("db_tables", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_alembic_migration",
+                return_value=CheckResult("alembic_migration", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instruments_exist",
+                return_value=CheckResult("instruments_exist", True, "warning", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_filestore_paths",
+                return_value=[
+                    CheckResult("instrument_filestore_paths", True, "warning", "ok")
+                ],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_harvesters",
+                return_value=[
+                    CheckResult("instrument_harvesters", True, "error", "ok")
+                ],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_timezones",
+                return_value=[
+                    CheckResult("instrument_timezones", True, "warning", "ok")
+                ],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_nemo_harvester_config",
+                return_value=[
+                    CheckResult("nemo_harvester_config", True, "warning", "ok")
+                ],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_data_path_writable",
+                return_value=CheckResult("data_path_writable", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_export_destinations",
+                return_value=CheckResult("export_destinations", True, "warning", "ok"),
+            ),
+        ):
+            results = run_preflight_checks(dry_run=False)
+
+        names = {r.name for r in results}
+        assert "data_path_writable" in names
+        assert "export_destinations" in names
+
+    def _all_checks_pass_patches(self):
+        """Return a list of (target, return_value) for all checks that pass."""
+        return [
+            (
+                "nexusLIMS.builder.preflight._check_db_reachable",
+                CheckResult("db_reachable", True, "error", "ok"),
+            ),
+            (
+                "nexusLIMS.builder.preflight._check_db_tables",
+                CheckResult("db_tables", True, "error", "ok"),
+            ),
+            (
+                "nexusLIMS.builder.preflight._check_alembic_migration",
+                CheckResult("alembic_migration", True, "error", "ok"),
+            ),
+            (
+                "nexusLIMS.builder.preflight._check_instruments_exist",
+                CheckResult("instruments_exist", True, "warning", "ok"),
+            ),
+        ]
+
+    def test_unexpected_exception_in_multi_check_returns_error_result(self):
+        """Unexpected exception in a multi-result check is caught and returned."""
+        with (
+            patch(
+                "nexusLIMS.builder.preflight._check_db_reachable",
+                return_value=CheckResult("db_reachable", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_db_tables",
+                return_value=CheckResult("db_tables", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_alembic_migration",
+                return_value=CheckResult("alembic_migration", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instruments_exist",
+                return_value=CheckResult("instruments_exist", True, "warning", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_filestore_paths",
+                side_effect=RuntimeError("multi boom"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_harvesters",
+                return_value=[],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_timezones",
+                return_value=[],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_nemo_harvester_config",
+                return_value=[],
+            ),
+        ):
+            results = run_preflight_checks(dry_run=True)
+
+        filestore_results = [
+            r for r in results if r.name == "instrument_filestore_paths"
+        ]
+        assert len(filestore_results) == 1
+        assert filestore_results[0].passed is False
+        assert "multi boom" in filestore_results[0].message
+
+    def test_unexpected_exception_in_write_check_returns_error_result(self):
+        """Unexpected exception in a write-path check is caught and returned."""
+        with (
+            patch(
+                "nexusLIMS.builder.preflight._check_db_reachable",
+                return_value=CheckResult("db_reachable", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_db_tables",
+                return_value=CheckResult("db_tables", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_alembic_migration",
+                return_value=CheckResult("alembic_migration", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instruments_exist",
+                return_value=CheckResult("instruments_exist", True, "warning", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_filestore_paths",
+                return_value=[],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_harvesters",
+                return_value=[],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_timezones",
+                return_value=[],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_nemo_harvester_config",
+                return_value=[],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_data_path_writable",
+                side_effect=RuntimeError("write boom"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_export_destinations",
+                return_value=CheckResult("export_destinations", True, "warning", "ok"),
+            ),
+        ):
+            results = run_preflight_checks(dry_run=False)
+
+        write_results = [r for r in results if r.name == "data_path_writable"]
+        assert len(write_results) == 1
+        assert write_results[0].passed is False
+        assert "write boom" in write_results[0].message
+
+    def test_unexpected_exception_in_single_check_returns_error_result(self):
+        """Unexpected exception in a check is caught and returned as FAIL result."""
+        with (
+            patch(
+                "nexusLIMS.builder.preflight._check_db_reachable",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_db_tables",
+                return_value=CheckResult("db_tables", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_alembic_migration",
+                return_value=CheckResult("alembic_migration", True, "error", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instruments_exist",
+                return_value=CheckResult("instruments_exist", True, "warning", "ok"),
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_filestore_paths",
+                return_value=[],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_harvesters",
+                return_value=[],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_instrument_timezones",
+                return_value=[],
+            ),
+            patch(
+                "nexusLIMS.builder.preflight._check_nemo_harvester_config",
+                return_value=[],
+            ),
+        ):
+            results = run_preflight_checks(dry_run=True)
+
+        db_reachable_results = [r for r in results if r.name == "db_reachable"]
+        assert len(db_reachable_results) == 1
+        assert db_reachable_results[0].passed is False
+        assert "boom" in db_reachable_results[0].message
+
+
+# ---------------------------------------------------------------------------
+# Integration: process_new_records raises PreflightError
+# ---------------------------------------------------------------------------
+
+
+class TestProcessNewRecordsAbortsOnPreflightError:
+    """Verify that process_new_records() raises PreflightError on error checks."""
+
+    def test_preflight_error_raised_on_error_check_failure(self):
+        failed_check = CheckResult(
+            name="db_reachable", passed=False, severity="error", message="DB missing"
+        )
+
+        with patch(
+            "nexusLIMS.builder.record_builder.run_preflight_checks",
+            return_value=[failed_check],
+        ):
+            from nexusLIMS.builder import record_builder
+
+            with pytest.raises(PreflightError) as exc_info:
+                record_builder.process_new_records(dry_run=True)
+
+        assert "db_reachable" in str(exc_info.value)
+
+    def test_no_preflight_error_when_all_pass(self):
+        passing_check = CheckResult(
+            name="db_reachable", passed=True, severity="error", message="ok"
+        )
+
+        with (
+            patch(
+                "nexusLIMS.builder.record_builder.run_preflight_checks",
+                return_value=[passing_check],
+            ),
+            # Stop after preflight — don't actually run the record builder
+            patch(
+                "nexusLIMS.builder.record_builder.get_sessions_to_build",
+                return_value=[],
+            ),
+            patch(
+                "nexusLIMS.builder.record_builder.nemo_utils.get_usage_events_as_sessions",
+                return_value=[],
+            ),
+        ):
+            from nexusLIMS.builder import record_builder
+
+            # Should not raise — empty sessions list causes early return
+            record_builder.process_new_records(dry_run=True)

--- a/tests/unit/test_record_builder/test_record_builder.py
+++ b/tests/unit/test_record_builder/test_record_builder.py
@@ -97,6 +97,7 @@ def skip_preview_generation(monkeypatch):
     instruments=["FEI-Titan-TEM", "JEOL-JEM-TEM", "TEST-TOOL"],
     sessions=True,
 )
+@pytest.mark.usefixtures("mock_preflight_pass")
 class TestRecordBuilder:
     """Tests the record building module."""
 


### PR DESCRIPTION
## Summary

- Adds `run_preflight_checks()` in `nexusLIMS/builder/preflight.py` that validates the environment before any harvesting or record-building begins
- Ten checks cover DB reachability, Alembic migration status, instrument configuration, NX_DATA_PATH writability, export destination config, and NEMO connectivity (with exponential-backoff retry)
- `process_new_records()` now runs all checks up-front and raises `PreflightError` if any error-severity check fails; the CLI catches `PreflightError` and logs structured per-check failure details
- Also adds `alembic.ini` at the project root (removes redundant `[tool.alembic]` from `pyproject.toml`) and fixes `CDCSDestination` to handle an empty workspace list without raising `IndexError`

## Changes

- **`nexusLIMS/builder/preflight.py`** (new): Core preflight check module with all ten environment validation checks
- **`nexusLIMS/builder/record_builder.py`**: Calls `run_preflight_checks()` at startup, raises `PreflightError` on failures
- **`nexusLIMS/cli/process_records.py`**: Catches `PreflightError` and logs structured failure details
- **`nexusLIMS/exporters/destinations/cdcs.py`**: Fixes empty workspace list `IndexError`
- **`alembic.ini`**: Added at project root; removed redundant `[tool.alembic]` section from `pyproject.toml`

## Test plan

- [ ] Unit tests in `tests/unit/test_record_builder/test_preflight.py` achieve 100% coverage of `preflight.py`
- [ ] Integration tests in `tests/integration/test_preflight_integration.py` verify checks against live Docker services
- [ ] Additional unit tests in `tests/unit/cli/test_process_records.py` cover CLI `PreflightError` handling
- [ ] Run `./scripts/run_tests.sh` to confirm all tests pass

Closes #57