### PR TITLE
feat(cli): add `nexuslims instruments list` command

### DIFF
--- a/docs/changes/79.feature.md
+++ b/docs/changes/79.feature.md
@@ -1,0 +1,3 @@
+Added `nexuslims instruments list` command to print a summary table of all
+instruments in the database, including session and completed-record counts.
+Supports `--format json` for scripting.

--- a/docs/user_guide/cli_reference.md
+++ b/docs/user_guide/cli_reference.md
@@ -465,6 +465,105 @@ For a complete guide with screenshots and demonstrations, see the {doc}`instrume
 
 ---
 
+(nexuslims-instruments-list)=
+## `nexuslims instruments list`
+
+Print a summary of all instruments in the database without launching the full
+TUI. Useful for quick status checks and scripting.
+
+### Basic Usage
+
+```bash
+nexuslims instruments list --help
+```
+
+```text
+Usage: nexuslims instruments list [OPTIONS]
+
+  List all instruments in the database.
+
+Options:
+  -f, --format [table|json]  Output format.  [default: table]
+  --help                     Show this message and exit.
+```
+
+### Output Formats
+
+#### Table (default)
+
+```bash
+nexuslims instruments list
+```
+
+```text
+                    NexusLIMS Instruments (2 total)
+┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
+┃ ID               ┃ Display Name     ┃ Location ┃ API URL              ┃ Sessions ┃ Last Session         ┃
+┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
+│ FEI-Titan-TEM-01 │ FEI Titan TEM    │ Room 123 │ https://ne…?id=1     │       15 │ 2025-11-03 14:22 EST │
+│ JEOL-ARM-200F-67 │ JEOL ARM 200F    │ Room 456 │ https://ne…?id=42    │        8 │ 2025-09-15 09:05 EDT │
+└──────────────────┴──────────────────┴──────────┴──────────────────────┴──────────┴──────────────────────┘
+```
+
+Columns:
+
+- **ID** — the `instrument_pid` (primary key in the database)
+- **Display Name** — human-readable name shown in NexusLIMS records
+- **Location** — physical location (building and room)
+- **API URL** — NEMO tool API endpoint (long URLs are middle-truncated so both
+  the server host and the query parameters remain visible)
+- **Sessions** — number of distinct sessions recorded for this instrument (based
+  on `END` events in `session_log`)
+- **Last Session** — timestamp of the most recent session end, localized to the
+  instrument's configured timezone; `—` if no sessions exist yet
+
+#### JSON (`--format json`)
+
+```bash
+nexuslims instruments list --format json
+```
+
+```json
+[
+  {
+    "instrument_pid": "FEI-Titan-TEM-01",
+    "display_name": "FEI Titan TEM",
+    "location": "Room 123",
+    "api_url": "https://nemo.example.com/api/tools/?id=1",
+    "harvester": "nemo",
+    "sessions_total": 15,
+    "last_session": "2025-11-03T14:22:00-05:00"
+  }
+]
+```
+
+The `last_session` field is an ISO-8601 string with timezone offset, localized
+to each instrument's configured timezone, or `null` if no sessions exist.
+
+### Examples
+
+```bash
+# Print table to terminal
+nexuslims instruments list
+
+# Pipe JSON to jq for scripting
+nexuslims instruments list --format json | jq '.[].instrument_pid'
+
+# Count total instruments
+nexuslims instruments list --format json | jq 'length'
+
+# Find instruments with no sessions yet
+nexuslims instruments list --format json | jq '[.[] | select(.sessions_total == 0)]'
+```
+
+```{note}
+`nexuslims instruments list` is a read-only command — it never modifies the
+database. To add, edit, or delete instruments, use
+`nexuslims instruments manage`.
+```
+
+---
+
 ## `nexuslims config`
 
 Configuration management utility for viewing and exporting NexusLIMS configuration.

--- a/docs/user_guide/instrument_manager.md
+++ b/docs/user_guide/instrument_manager.md
@@ -17,6 +17,12 @@ uv run nexuslims instruments manage
 
 The TUI will automatically initialize the database if it doesn't exist yet.
 
+```{tip}
+Need a quick, scriptable summary of your instruments without opening the TUI?
+Use `nexuslims instruments list` for a plain-text table or JSON output.
+See the {ref}`nexuslims-instruments-list` section of the CLI reference for details.
+```
+
 ## Main Interface
 
 When you launch the instrument manager, you'll see a table listing all instruments in the database:
@@ -204,6 +210,6 @@ If form validation fails:
 
 ## See Also
 
-- {doc}`cli_reference` - Full CLI command reference
+- {doc}`cli_reference` - Full CLI command reference (includes `nexuslims instruments list`)
 - {doc}`/user_guide/migrations` - Database schema management
 - {doc}`/dev_guide/database` - Database schema documentation

--- a/nexusLIMS/cli/main.py
+++ b/nexusLIMS/cli/main.py
@@ -15,6 +15,7 @@ Usage
     nexuslims config [dump|load|edit]
     nexuslims db [init|upgrade|...]
     nexuslims instruments manage
+    nexuslims instruments list
 """
 
 from __future__ import annotations
@@ -112,6 +113,26 @@ def _build_instruments_group() -> click.Group:
 
         _ensure_database_initialized()
         _run_instrument_manager()
+
+    @instruments.command(name="list")
+    @click.option(
+        "--format",
+        "-f",
+        "output_format",
+        type=click.Choice(["table", "json"]),
+        default="table",
+        show_default=True,
+        help="Output format.",
+    )
+    def list_instruments(output_format: str) -> None:
+        """List all instruments in the database."""
+        from nexusLIMS.cli.manage_instruments import (  # noqa: PLC0415
+            _ensure_database_initialized,
+            _list_instruments,
+        )
+
+        _ensure_database_initialized()
+        _list_instruments(output_format=output_format)
 
     return instruments
 

--- a/nexusLIMS/cli/manage_instruments.py
+++ b/nexusLIMS/cli/manage_instruments.py
@@ -1,8 +1,8 @@
 """
 CLI entry point for the NexusLIMS instrument management TUI.
 
-Provides the ``nexuslims instruments manage`` command for interactive
-database management.
+Provides the ``nexuslims instruments manage`` and ``nexuslims instruments list``
+commands for interactive and scriptable database management.
 
 Usage
 -----
@@ -11,6 +11,12 @@ Usage
 
     # Launch the instrument management TUI
     nexuslims instruments manage
+
+    # List instruments in a table
+    nexuslims instruments list
+
+    # List instruments as JSON
+    nexuslims instruments list --format json
 
     # Show version information
     nexuslims instruments manage --version
@@ -26,6 +32,7 @@ Features
 - Automatic database initialization (if NX_DB_PATH doesn't exist yet)
 """
 
+import json
 import logging
 import os
 from pathlib import Path
@@ -94,6 +101,132 @@ def _ensure_database_initialized() -> None:
             if db_path.exists():
                 db_path.unlink()
             raise click.Abort from e
+
+
+def _truncate_url_middle(url: str, max_width: int = 22) -> str:
+    """Truncate a URL in the middle to fit within max_width characters.
+
+    Preserves the beginning (scheme + host) and the end (query string / path
+    tail) so that both the server and the tool ID remain readable.
+
+    Parameters
+    ----------
+    url
+        The URL string to truncate.
+    max_width
+        Maximum character width of the result.
+
+    Returns
+    -------
+    str
+        The original URL if it fits, otherwise a middle-truncated version
+        with ``…`` in the middle.
+    """
+    if len(url) <= max_width:
+        return url
+    # Reserve 1 char for the ellipsis
+    half = (max_width - 1) // 2
+    return url[:half] + "…" + url[-(max_width - half - 1) :]
+
+
+def _list_instruments(output_format: str = "table") -> None:
+    """Print a summary of all instruments in the database.
+
+    Parameters
+    ----------
+    output_format
+        Either ``"table"`` (default, Rich formatted) or ``"json"``.
+    """
+    from sqlalchemy import func  # noqa: PLC0415
+    from sqlmodel import Session as DBSession  # noqa: PLC0415
+    from sqlmodel import select  # noqa: PLC0415
+
+    from nexusLIMS.db.engine import get_engine  # noqa: PLC0415
+    from nexusLIMS.db.enums import EventType  # noqa: PLC0415
+    from nexusLIMS.db.models import Instrument, SessionLog  # noqa: PLC0415
+
+    with DBSession(get_engine()) as session:
+        instruments = session.exec(select(Instrument)).all()
+
+        if not instruments:
+            click.echo(
+                "No instruments found. Use 'nexuslims instruments manage' to add "
+                "instruments."
+            )
+            return
+
+        # Build per-instrument stats: (total_sessions, last_session_dt)
+        stats: dict[str, tuple[int, object]] = {}
+        for inst in instruments:
+            row = session.exec(
+                select(
+                    func.count(func.distinct(SessionLog.session_identifier)),
+                    func.max(SessionLog.timestamp),
+                ).where(
+                    SessionLog.instrument == inst.instrument_pid,
+                    SessionLog.event_type == EventType.END,
+                )
+            ).one()
+            total_sessions, last_ts = row
+            stats[inst.instrument_pid] = (total_sessions or 0, last_ts)
+
+    if output_format == "json":
+        records = []
+        for inst in instruments:
+            total_sessions, last_ts = stats[inst.instrument_pid]
+            last_session_str: str | None = None
+            if last_ts is not None:
+                localized = inst.localize_datetime(last_ts)
+                last_session_str = localized.isoformat()
+            records.append(
+                {
+                    "instrument_pid": inst.instrument_pid,
+                    "display_name": inst.display_name,
+                    "location": inst.location,
+                    "api_url": inst.api_url,
+                    "harvester": inst.harvester,
+                    "sessions_total": total_sessions,
+                    "last_session": last_session_str,
+                }
+            )
+        click.echo(json.dumps(records, indent=2))
+        return
+
+    # Rich table output
+    from rich.console import Console  # noqa: PLC0415
+    from rich.table import Table  # noqa: PLC0415
+
+    n = len(instruments)
+    table = Table(
+        title=f"NexusLIMS Instruments ({n} total)",
+        show_header=True,
+        header_style="bold",
+    )
+    table.add_column("ID", no_wrap=True)
+    table.add_column("Display Name")
+    table.add_column("Location")
+    table.add_column("API URL", no_wrap=True)
+    table.add_column("Sessions", justify="right")
+    table.add_column("Last Session", no_wrap=True)
+
+    for inst in instruments:
+        total_sessions, last_ts = stats[inst.instrument_pid]
+        if last_ts is not None:
+            localized = inst.localize_datetime(last_ts)
+            last_session_str = localized.strftime("%Y-%m-%d %H:%M %Z")
+        else:
+            last_session_str = "—"
+        table.add_row(
+            inst.instrument_pid,
+            inst.display_name,
+            inst.location,
+            _truncate_url_middle(inst.api_url),
+            str(total_sessions),
+            last_session_str,
+        )
+
+    console = Console()
+    console.print(table)
 
 
 def _run_instrument_manager() -> None:

--- a/tests/unit/test_cli/test_list_instruments.py
+++ b/tests/unit/test_cli/test_list_instruments.py
@@ -1,0 +1,243 @@
+"""Tests for the ``nexuslims instruments list`` CLI command."""
+
+import datetime
+import json
+from unittest.mock import MagicMock, patch
+
+import pytz
+from click.testing import CliRunner
+
+from nexusLIMS.cli.main import main
+from nexusLIMS.cli.manage_instruments import _truncate_url_middle
+
+
+class TestTruncateUrlMiddle:
+    """Tests for _truncate_url_middle helper."""
+
+    def test_short_url_unchanged(self):
+        url = "https://nemo.example.com/"
+        assert _truncate_url_middle(url, max_width=40) == url
+
+    def test_exact_width_unchanged(self):
+        url = "https://nemo.example.com/?id=1"
+        assert _truncate_url_middle(url, max_width=len(url)) == url
+
+    def test_long_url_truncated(self):
+        url = "https://nemo.example.com/api/tools/?id=12345"
+        result = _truncate_url_middle(url, max_width=22)
+        assert len(result) == 22
+        assert "…" in result
+
+    def test_truncated_preserves_start_and_end(self):
+        url = "https://nemo.example.com/api/tools/?id=123"
+        result = _truncate_url_middle(url, max_width=20)
+        assert result.startswith("https://")
+        assert result.endswith(url[-9:])
+
+
+class TestListInstrumentsCommand:
+    """Tests for ``nexuslims instruments list`` via CliRunner."""
+
+    def _make_instrument(self, pid, display_name, location, api_url):
+        inst = MagicMock()
+        inst.instrument_pid = pid
+        inst.display_name = display_name
+        inst.location = location
+        inst.api_url = api_url
+        inst.harvester = "nemo"
+        inst.timezone_str = "America/New_York"
+        tz = pytz.timezone("America/New_York")
+        inst.localize_datetime = lambda dt: dt.astimezone(tz)
+        return inst
+
+    def test_help_shows_expected_text(self):
+        runner = CliRunner()
+        result = runner.invoke(main, ["instruments", "list", "--help"])
+        assert result.exit_code == 0
+        assert "List all instruments in the database" in result.output
+        assert "--format" in result.output
+
+    def test_table_output_with_instruments(self, monkeypatch):
+        """Table output lists instrument IDs and display names."""
+        inst1 = self._make_instrument(
+            "FEI-Titan-TEM-01",
+            "FEI Titan TEM",
+            "Room 123",
+            "https://nemo.example.com/api/tools/?id=1",
+        )
+        inst2 = self._make_instrument(
+            "JEOL-ARM-200F-67",
+            "JEOL ARM 200F",
+            "Room 456",
+            "https://nemo.example.com/api/tools/?id=42",
+        )
+
+        last_ts = datetime.datetime(2025, 11, 3, 19, 22, 0, tzinfo=pytz.UTC)
+
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session.exec.side_effect = [
+            MagicMock(all=MagicMock(return_value=[inst1, inst2])),
+            MagicMock(one=MagicMock(return_value=(15, last_ts))),
+            MagicMock(one=MagicMock(return_value=(8, last_ts))),
+        ]
+
+        with (
+            patch("dotenv.load_dotenv"),
+            patch("os.getenv", return_value="/fake/path/db.db"),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("nexusLIMS.db.engine.get_engine"),
+            patch("sqlmodel.Session", return_value=mock_session),
+        ):
+            runner = CliRunner()
+            # Use wide terminal so Rich doesn't compress table columns
+            result = runner.invoke(
+                main,
+                ["instruments", "list"],
+                catch_exceptions=False,
+                env={"COLUMNS": "200"},
+            )
+
+        assert result.exit_code == 0
+        assert "FEI-Titan-TEM-01" in result.output
+        assert "FEI Titan TEM" in result.output
+        assert "JEOL-ARM-200F-67" in result.output
+        assert "JEOL ARM 200F" in result.output
+
+    def test_json_output_format(self, monkeypatch):
+        """JSON output is valid JSON with expected keys."""
+        inst = self._make_instrument(
+            "FEI-Titan-TEM-01",
+            "FEI Titan TEM",
+            "Room 123",
+            "https://nemo.example.com/api/tools/?id=1",
+        )
+        last_ts = datetime.datetime(2025, 11, 3, 19, 22, 0, tzinfo=pytz.UTC)
+
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session.exec.side_effect = [
+            MagicMock(all=MagicMock(return_value=[inst])),
+            MagicMock(one=MagicMock(return_value=(15, last_ts))),
+        ]
+
+        with (
+            patch("dotenv.load_dotenv"),
+            patch("os.getenv", return_value="/fake/path/db.db"),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("nexusLIMS.db.engine.get_engine"),
+            patch("sqlmodel.Session", return_value=mock_session),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["instruments", "list", "--format", "json"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert isinstance(data, list)
+        assert len(data) == 1
+        record = data[0]
+        assert record["instrument_pid"] == "FEI-Titan-TEM-01"
+        assert record["display_name"] == "FEI Titan TEM"
+        assert record["sessions_total"] == 15
+        assert record["last_session"] is not None
+        assert record["harvester"] == "nemo"
+
+    def test_json_output_null_last_session(self):
+        """JSON output has null last_session when no sessions exist."""
+        inst = self._make_instrument(
+            "FEI-Titan-TEM-01",
+            "FEI Titan TEM",
+            "Room 123",
+            "https://nemo.example.com/api/tools/?id=1",
+        )
+
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session.exec.side_effect = [
+            MagicMock(all=MagicMock(return_value=[inst])),
+            MagicMock(one=MagicMock(return_value=(0, None))),
+        ]
+
+        with (
+            patch("dotenv.load_dotenv"),
+            patch("os.getenv", return_value="/fake/path/db.db"),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("nexusLIMS.db.engine.get_engine"),
+            patch("sqlmodel.Session", return_value=mock_session),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["instruments", "list", "--format", "json"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data[0]["sessions_total"] == 0
+        assert data[0]["last_session"] is None
+
+    def test_table_output_null_last_session(self):
+        """Table output shows em dash when no sessions exist for an instrument."""
+        inst = self._make_instrument(
+            "FEI-Titan-TEM-01",
+            "FEI Titan TEM",
+            "Room 123",
+            "https://nemo.example.com/api/tools/?id=1",
+        )
+
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session.exec.side_effect = [
+            MagicMock(all=MagicMock(return_value=[inst])),
+            MagicMock(one=MagicMock(return_value=(0, None))),
+        ]
+
+        with (
+            patch("dotenv.load_dotenv"),
+            patch("os.getenv", return_value="/fake/path/db.db"),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("nexusLIMS.db.engine.get_engine"),
+            patch("sqlmodel.Session", return_value=mock_session),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main,
+                ["instruments", "list"],
+                catch_exceptions=False,
+                env={"COLUMNS": "200"},
+            )
+
+        assert result.exit_code == 0
+        assert "—" in result.output
+
+    def test_empty_database_message(self):
+        """Empty database prints a helpful message instead of a table."""
+        mock_session = MagicMock()
+        mock_session.__enter__ = MagicMock(return_value=mock_session)
+        mock_session.__exit__ = MagicMock(return_value=False)
+        mock_session.exec.return_value = MagicMock(all=MagicMock(return_value=[]))
+
+        with (
+            patch("dotenv.load_dotenv"),
+            patch("os.getenv", return_value="/fake/path/db.db"),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("nexusLIMS.db.engine.get_engine"),
+            patch("sqlmodel.Session", return_value=mock_session),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                main, ["instruments", "list"], catch_exceptions=False
+            )
+
+        assert result.exit_code == 0
+        assert "No instruments found" in result.output
+        assert "nexuslims instruments manage" in result.output


### PR DESCRIPTION
## Summary

Closes #79.

Adds a new read-only `nexuslims instruments list` CLI subcommand that gives operators and scripts a quick view of all instruments registered in the database without launching the full interactive TUI.

## Changes

- **`nexusLIMS/cli/manage_instruments.py`**: Add `_list_instruments()` function with Rich table and JSON output paths, plus `_truncate_url_middle()` helper that keeps long API URLs readable at narrow terminal widths by preserving the scheme/host and the tail.
- **`nexusLIMS/cli/main.py`**: Register the `nexuslims instruments list` subcommand with `--format {table,json}` option.
- **`tests/unit/test_cli/test_list_instruments.py`**: 243-line test module covering table output, JSON output, null last-session, empty-database edge case, and URL truncation.
- **`docs/user_guide/cli_reference.md`**: Document the new subcommand with example output.
- **`docs/user_guide/instrument_manager.md`**: Cross-reference the new list command from the instrument manager page.
- **`docs/changes/79.feature.md`**: Towncrier changelog entry.

## Usage

```bash
# Human-readable Rich table (default)
nexuslims instruments list

# Machine-readable JSON for scripting
nexuslims instruments list --format json
```

## Test plan

- [x] `uv run pytest tests/unit/test_cli/test_list_instruments.py -v` — all new unit tests pass
- [x] `nexuslims instruments list` renders a Rich table against a populated database
- [x] `nexuslims instruments list --format json` emits valid JSON parseable by `jq`
- [x] `nexuslims instruments list` on an empty database prints a helpful message