### PR TITLE
feat: add interactive TUI database browser (nexuslims db view)

### DIFF
--- a/docs/changes/80.feature.md
+++ b/docs/changes/80.feature.md
@@ -1,0 +1,1 @@
+Added `nexuslims db view` command that opens an interactive TUI browser for the NexusLIMS SQLite database, powered by [Squall](https://github.com/driscollis/squall). Users can browse instruments, sessions, uploads, and other tables, filter rows, and run custom SQL queries — all from the terminal.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -432,6 +432,7 @@ nitpick_ignore_regex = [
     (r"py:(obj|class)", r"rich\..*"),
     (r"py:(obj|class)", r"sqlmodel\..*"),
     (r"py:(obj|class)", r"click\..*"),
+    (r"py:(obj|class)", r"squall\..*"),
 ]
 
 

--- a/docs/user_guide/cli_reference.md
+++ b/docs/user_guide/cli_reference.md
@@ -707,13 +707,15 @@ Options:
   --help     Show this message and exit.
 
 Commands:
-  alembic    Run Alembic commands directly (advanced usage).
-  check      Check if the database has pending migrations.
-  current    Show the current database migration version.
-  downgrade  Downgrade database to an earlier version.
-  history    Show migration history.
-  init       Initialize a new NexusLIMS database.
-  upgrade    Upgrade database to a later version.
+  alembic      Run Alembic commands directly (advanced usage).
+  check        Check if the database has pending migrations.
+  create-demo  Create a demo database pre-populated with sample instruments.
+  current      Show the current database migration version.
+  downgrade    Downgrade database to an earlier version.
+  history      Show migration history.
+  init         Initialize a new NexusLIMS database.
+  upgrade      Upgrade database to a later version.
+  view         Open a read-only TUI browser for the NexusLIMS database.
 ```
 
 ### Commands
@@ -893,6 +895,115 @@ nexuslims db history
 # Show verbose history with current revision marked
 nexuslims db history -v -i
 ```
+
+#### `view`
+
+Open a read-only TUI browser for the NexusLIMS database.
+
+Launches a Textual-based interactive browser pointed at the database configured
+via `NX_DB_PATH`. The browser is **read-only** — no SQL execution or data
+modification is possible.
+
+**Usage:**
+```bash
+nexuslims db view
+```
+
+![DB Browser — Table Viewer showing the instruments table](../images/tui/screenshots/db_browser_table_viewer.svg)
+
+**Tabs available inside the browser:**
+
+- **Table Viewer** — Browse rows in any table with a live filter input and
+  sortable column headers. Click any column header to sort ascending; click
+  again to sort descending; click a third time to clear sorting. Type in the
+  filter box to narrow results across all columns simultaneously (up to 1 000
+  rows shown at once).
+- **Database Structure** — Inspect the schema: tables, columns, types, and
+  indexes.
+
+**Keybindings (inside the browser):**
+
+| Key | Action |
+|-----|--------|
+| `Tab` / `Shift+Tab` | Navigate between panels |
+| `Enter` | Select / confirm |
+| `q` / `Ctrl+Q` | Quit |
+
+**Prerequisites:**
+
+- `NX_DB_PATH` must be set (via `.env` or environment)
+- The database file must already exist (run `nexuslims db init` first)
+
+**Examples:**
+```bash
+# Open the database browser
+nexuslims db view
+```
+
+**Error handling:**
+- Exits with a clear error message if `NX_DB_PATH` is not set
+- Exits with a clear error message if the database file does not exist
+
+```{note}
+`nexuslims db view` is a read-only command — it cannot modify the database.
+To manage instruments, use `nexuslims instruments manage`. To explore a
+pre-populated example database, create one first with `nexuslims db
+create-demo`.
+```
+
+---
+
+#### `create-demo`
+
+Create a demo SQLite database pre-populated with 10 sample instruments.
+
+Useful for exploring NexusLIMS without a live NEMO instance, testing the TUI,
+or generating documentation screenshots.
+
+**Usage:**
+```bash
+nexuslims db create-demo [PATH] [OPTIONS]
+```
+
+**Arguments:**
+- `PATH` (optional) — destination file path for the demo database. Defaults to
+  `nexuslims_demo.db` in the current working directory.
+
+**Options:**
+- `--force` — Overwrite the file if it already exists
+
+**Examples:**
+```bash
+# Create demo database in the current directory (nexuslims_demo.db)
+nexuslims db create-demo
+
+# Create at a specific path
+nexuslims db create-demo /tmp/demo.db
+
+# Overwrite an existing file
+nexuslims db create-demo ./my_demo.db --force
+```
+
+**Typical workflow — browse the demo database:**
+```bash
+# 1. Create a demo database
+nexuslims db create-demo
+
+# 2. Browse it in the TUI
+NX_DB_PATH=./nexuslims_demo.db nexuslims db view
+
+# 3. Or explore instruments in the instrument manager
+NX_DB_PATH=./nexuslims_demo.db nexuslims instruments manage
+```
+
+```{note}
+The demo database is a self-contained SQLite file that can be opened with any
+SQLite client (e.g. [DB Browser for SQLite](https://sqlitebrowser.org/) or the
+`sqlite3` CLI). It is not connected to any NEMO instance and contains no real
+session data.
+```
+
+---
 
 #### `alembic`
 

--- a/nexusLIMS/cli/main.py
+++ b/nexusLIMS/cli/main.py
@@ -13,7 +13,7 @@ Usage
     nexuslims --version
     nexuslims build-records [OPTIONS]
     nexuslims config [dump|load|edit]
-    nexuslims db [init|upgrade|...]
+    nexuslims db [init|upgrade|view|...]
     nexuslims instruments manage
     nexuslims instruments list
 """

--- a/nexusLIMS/cli/migrate.py
+++ b/nexusLIMS/cli/migrate.py
@@ -23,6 +23,12 @@ Usage
     # Downgrade one migration
     nexuslims db downgrade
 
+    # Browse the database interactively
+    nexuslims db view
+
+    # Create a demo database with sample instruments
+    nexuslims db create-demo [PATH]
+
     # Advanced: Run any Alembic command
     nexuslims db alembic history --verbose
 
@@ -487,6 +493,101 @@ def _cli():  # noqa: PLR0915
             # Clean up the temporary config file
             with contextlib.suppress(OSError):
                 tmp_config_path.unlink()
+
+    @cli.command("create-demo")
+    @click.argument(
+        "path",
+        type=click.Path(dir_okay=False, path_type=Path),
+        default=None,
+        required=False,
+    )
+    @click.option(
+        "--force",
+        is_flag=True,
+        help="Overwrite the file if it already exists.",
+    )
+    def create_demo(path, force):
+        """Create a demo database pre-populated with sample instruments.
+
+        Creates a SQLite database containing 10 sample instruments with
+        diverse configurations, useful for testing the TUI, generating
+        documentation screenshots, or exploring NexusLIMS without a live
+        NEMO instance.
+
+        PATH defaults to a file named ``nexuslims_demo.db`` in the current
+        working directory when not supplied.
+
+        \b
+        Examples:
+          nexuslims db create-demo
+          nexuslims db create-demo /tmp/demo.db
+          nexuslims db create-demo ./my_demo.db --force
+        """  # noqa: D301
+        import sys
+
+        from nexusLIMS.tui.demo_helpers import create_demo_database
+
+        if path is None:
+            path = Path.cwd() / "nexuslims_demo.db"
+
+        if path.exists() and not force:
+            click.secho(f"Error: file already exists at {path}", fg="red", err=True)
+            click.echo("Use --force to overwrite it.", err=True)
+            sys.exit(1)
+
+        if force and path.exists():
+            path.unlink()
+        click.echo(f"Creating demo database at {path}\u2026")
+        try:
+            create_demo_database(path)
+            click.secho(f"\u2713 Demo database created at {path}", fg="green")
+        except Exception as e:
+            click.secho(f"Error: {e}", fg="red", err=True)
+            sys.exit(1)
+
+    @cli.command()
+    def view():
+        """Open a read-only TUI browser for the NexusLIMS database.
+
+        Launches a Textual-based SQLite browser pointed at the database
+        configured via NX_DB_PATH.  You can browse tables and inspect rows
+        across all NexusLIMS tables (instruments, session_log, upload_log,
+        external_user_identifiers).
+
+        \b
+        Keybindings (inside the browser):
+        ----------------------------------
+          - Tab / Shift+Tab   Navigate between panels
+          - Enter             Select / confirm
+          - q / Ctrl+Q        Quit
+        """  # noqa: D301
+        import os
+        import sys
+        from argparse import Namespace
+
+        db_path_str = os.getenv("NX_DB_PATH")
+        if not db_path_str:
+            click.secho(
+                "Error: NX_DB_PATH environment variable is not set.", fg="red", err=True
+            )
+            click.echo(
+                "Run 'nexuslims config edit' or set NX_DB_PATH manually.", err=True
+            )
+            sys.exit(1)
+
+        if not Path(db_path_str).exists():
+            click.secho(
+                f"Error: Database does not exist at {db_path_str}",
+                fg="red",
+                err=True,
+            )
+            click.echo("Run 'nexuslims db init' to create the database.", err=True)
+            sys.exit(1)
+
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSDBApp
+
+        app = NexusLIMSDBApp(Namespace(filepath=db_path_str))
+        app.run()
 
     return cli
 

--- a/nexusLIMS/tui/apps/db_browser.py
+++ b/nexusLIMS/tui/apps/db_browser.py
@@ -1,0 +1,236 @@
+"""Read-only NexusLIMS database browser TUI.
+
+Provides :class:`NexusLIMSDBApp`, a Textual app that wraps Squall's
+``SQLiteClientApp`` to give a stripped-down, read-only view of the database:
+
+* The "Open Database" button and "Execute SQL" tab are removed.
+* The Table Viewer tab gains a live filter input and click-to-sort column
+  headers, both implemented via parameterised SQL queries so they compose
+  correctly and never expose the database to modification.
+
+Usage
+-----
+
+.. code-block:: python
+
+    from argparse import Namespace
+    from nexusLIMS.tui.apps.db_browser import NexusLIMSDBApp
+
+    app = NexusLIMSDBApp(Namespace(filepath="/path/to/nexuslims.db"))
+    app.run()
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from squall import db_utility
+from squall.database_structure_tree import DatabaseStructurePane
+from squall.squall import SQLiteClientApp
+from textual import on
+from textual.widgets import DataTable, Input, Select, TabbedContent, TabPane
+from textual.widgets._select import NULL as SELECT_BLANK
+
+if TYPE_CHECKING:
+    from textual.app import ComposeResult
+
+# ---------------------------------------------------------------------------
+# Resolve squall's stylesheet at import time so the subclass can reference it
+# as a class variable regardless of where *this* module lives on disk.
+# ---------------------------------------------------------------------------
+import squall as _squall_pkg
+
+_SQUALL_TCSS = str(Path(_squall_pkg.__file__).parent / "squall.tcss")
+
+
+class NexusLIMSTableViewerPane(TabPane):
+    """Table viewer with live full-text filter and sortable column headers.
+
+    All filtering and sorting is performed via parameterised SQL queries
+    so they compose naturally and the database is never modified.
+    """
+
+    DEFAULT_CSS = """
+    NexusLIMSTableViewerPane {
+        Select {
+            margin: 1;
+            border: round gold;
+        }
+
+        #filter_input {
+            margin: 1;
+            border: round $accent;
+            width: 100%;
+        }
+
+        DataTable {
+            margin: 1;
+            border: round gold;
+            height: 1fr;
+        }
+    }
+    """
+
+    def __init__(self, db_path: Path, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.db_path = db_path
+        self.tables: list[str] = sorted(db_utility.get_table_names(db_path))
+        self._filter_text: str = ""
+        self._sort_col: str | None = None
+        self._sort_asc: bool = True
+        self._col_names: list[str] = []
+
+    def compose(self) -> ComposeResult:
+        """Build the table viewer layout."""
+        yield Select.from_values(
+            self.tables, id="table_names_select", value=self.tables[0]
+        )
+        yield Input(
+            placeholder="Filter rows… (searches all columns)",
+            id="filter_input",
+        )
+        yield DataTable(id="sqlite_table_data")
+
+    def on_mount(self) -> None:
+        """Load the initial table on mount."""
+        # Inline style wins over squall's CSS_PATH rule (Input { width: 80% })
+        self.query_one("#filter_input", Input).styles.width = "100%"
+        self._load_table()
+
+    # ------------------------------------------------------------------
+    # Event handlers
+    # ------------------------------------------------------------------
+
+    @on(Select.Changed, "#table_names_select")
+    def _on_table_changed(self, event: Select.Changed) -> None:
+        """Reset filter and sort state when the selected table changes."""
+        if event.value is SELECT_BLANK:
+            return
+        self._filter_text = ""
+        self._sort_col = None
+        self._sort_asc = True
+        self.query_one("#filter_input", Input).value = ""
+        self._load_table()
+
+    @on(Input.Changed, "#filter_input")
+    def _on_filter_changed(self, event: Input.Changed) -> None:
+        """Re-query the database whenever the filter text changes."""
+        self._filter_text = event.value
+        self._load_table()
+
+    @on(DataTable.HeaderSelected, "#sqlite_table_data")
+    def _on_header_selected(self, event: DataTable.HeaderSelected) -> None:
+        """Cycle sort direction on repeated clicks; change column otherwise."""
+        clicked_col = event.column_key.value  # str key we supplied to add_column
+        if self._sort_col == clicked_col:
+            if self._sort_asc:
+                self._sort_asc = False
+            else:
+                # Third click on the same column clears sorting
+                self._sort_col = None
+                self._sort_asc = True
+        else:
+            self._sort_col = clicked_col
+            self._sort_asc = True
+        self._load_table()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _load_table(self) -> None:
+        """Fetch rows from SQLite and populate the DataTable.
+
+        Builds a single parameterised ``SELECT`` statement that combines the
+        current filter text (``WHERE … LIKE ?``) and sort column
+        (``ORDER BY … ASC/DESC``) so both features compose correctly.
+        """
+        table_name = str(self.app.query_one("#table_names_select", Select).value)
+        filter_text = self._filter_text.strip()
+
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+
+        # Discover column names without fetching any data
+        cursor.execute(f"SELECT * FROM {table_name} LIMIT 0")  # noqa: S608
+        col_names = [d[0] for d in cursor.description]
+        self._col_names = col_names
+
+        # Build WHERE clause — cast every column to TEXT so LIKE works on
+        # integers, datetimes, etc.
+        params: list[str] = []
+        where = ""
+        if filter_text:
+            conditions = [f"CAST({col} AS TEXT) LIKE ?" for col in col_names]
+            where = "WHERE " + " OR ".join(conditions)
+            params = [f"%{filter_text}%" for _ in col_names]
+
+        # Build ORDER BY clause
+        order = ""
+        if self._sort_col and self._sort_col in col_names:
+            direction = "ASC" if self._sort_asc else "DESC"
+            order = f"ORDER BY {self._sort_col} {direction}"
+
+        sql = f"SELECT * FROM {table_name} {where} {order} LIMIT 1000"  # noqa: S608
+        cursor.execute(sql, params)
+        rows = cursor.fetchall()
+        conn.close()
+
+        # Build display labels: add ↑/↓ to the sorted column header
+        display_labels = [self._sort_label(name) for name in col_names]
+
+        dt = self.query_one("#sqlite_table_data", DataTable)
+        dt.clear(columns=True)
+        for name, label in zip(col_names, display_labels):
+            dt.add_column(label, key=name)
+
+        if rows:
+            dt.add_rows(rows)
+        else:
+            dt.add_rows([tuple("" for _ in col_names)])
+
+        dt.cursor_type = "row"
+
+    def _sort_label(self, col_name: str) -> str:
+        """Return the display label for a column header, with sort indicator."""
+        if col_name == self._sort_col:
+            indicator = " ↑" if self._sort_asc else " ↓"
+            return f"{col_name}{indicator}"
+        return col_name
+
+
+class NexusLIMSDBApp(SQLiteClientApp):
+    """Read-only NexusLIMS database browser.
+
+    Extends Squall's ``SQLiteClientApp`` with:
+
+    * The "Open Database" button hidden (path always comes from ``NX_DB_PATH``)
+    * The "Execute SQL" tab removed to prevent accidental modifications
+    * The Table Viewer replaced with :class:`NexusLIMSTableViewerPane`, which
+      adds a live filter input and sortable column headers
+    """
+
+    CSS_PATH = _SQUALL_TCSS
+    DEFAULT_CSS = "#center { display: none; }"
+
+    async def update_ui(self, db_file_path: Path) -> None:
+        """Load the database into the read-only browser tabs."""
+        if not Path(db_file_path).exists():
+            self.notify("Database not found")
+            return
+
+        tabbed_content = self.query_one("#tabbed_ui", TabbedContent)
+        await tabbed_content.clear_panes()
+        await tabbed_content.add_pane(
+            NexusLIMSTableViewerPane(db_file_path, title="Table Viewer")
+        )
+        await tabbed_content.add_pane(
+            DatabaseStructurePane(
+                db_file_path,
+                title="Database Structure",
+                id="db_structure",
+            )
+        )
+        self.title = f"NexusLIMS DB — {db_file_path}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "sqlmodel>=0.0.31",
     "alembic>=1.17.2",
     "textual>=8.0.0",
+    "squall-sql>=0.1.8",
 ]
 
 [dependency-groups]

--- a/scripts/generate_tui_demos.py
+++ b/scripts/generate_tui_demos.py
@@ -238,6 +238,67 @@ def generate_svg_screenshots(demo_db_path: Path) -> None:
         raise
 
 
+def generate_db_browser_screenshots(demo_db_path: Path) -> None:
+    """Generate SVG screenshots for the database browser TUI.
+
+    Creates a static SVG screenshot of the Table Viewer tab with the
+    instruments table selected and columns sized to content via a mouse
+    hover over the DataTable.
+
+    Parameters
+    ----------
+    demo_db_path : Path
+        Path to the demo database to use for screenshots.
+    """
+    from argparse import Namespace
+
+    from nexusLIMS.tui.apps.db_browser import NexusLIMSDBApp, NexusLIMSTableViewerPane
+
+    print("Generating database browser SVG screenshots...")
+
+    try:
+        repo_root = Path(__file__).parent.parent
+        screenshots_dir = repo_root / "docs" / "images" / "tui" / "screenshots"
+        screenshots_dir.mkdir(parents=True, exist_ok=True)
+
+        app = NexusLIMSDBApp(Namespace(filepath=str(demo_db_path)))
+
+        async def capture_db_browser_screenshots():
+            """Async function to capture db browser screenshots."""
+            from textual.widgets import Select
+
+            async with app.run_test(size=(200, 50)) as pilot:
+                # Wait for app to fully load
+                await pilot.pause(0.5)
+
+                # Select the instruments table explicitly (it may not be first
+                # alphabetically if alembic_version or other tables exist)
+                pane = app.query_one(NexusLIMSTableViewerPane)
+                app.query_one("#table_names_select", Select).value = "instruments"
+                pane._load_table()
+                await pilot.pause(0.3)
+
+                # Sweep the mouse left-to-right across the DataTable so Textual
+                # recalculates column widths for each column as the cursor passes
+                # over it — the same effect as manually mousing across the widget.
+                terminal_width, _ = app.size
+                for x in range(0, terminal_width, 4):
+                    await pilot.hover("#sqlite_table_data", offset=(x, 5))
+                await pilot.pause(0.2)
+
+                screenshot_path = screenshots_dir / "db_browser_table_viewer.svg"
+                app.save_screenshot(screenshot_path)
+                print(f"  ✓ {screenshot_path.name}")
+
+        import asyncio
+
+        asyncio.run(capture_db_browser_screenshots())
+
+    except Exception as e:
+        print(f"✗ Failed to generate database browser screenshots: {e}")
+        raise
+
+
 def generate_config_svg_screenshots() -> None:
     """Generate SVG screenshots for the config TUI.
 
@@ -358,6 +419,9 @@ def main() -> int:
     # Generate SVG screenshots for instrument manager (always runs)
     _generate_instrument_screenshots_with_warnings(db_path)
 
+    # Generate SVG screenshots for db browser (always runs)
+    _generate_db_browser_screenshots_with_warnings(db_path)
+
     # Generate SVG screenshots for config TUI (always runs)
     _generate_config_screenshots_with_warnings()
 
@@ -423,6 +487,19 @@ def _generate_instrument_screenshots_with_warnings(db_path: Path) -> None:
         print()
     except Exception as e:
         print(f"! Warning: SVG screenshot generation failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        print()
+
+
+def _generate_db_browser_screenshots_with_warnings(db_path: Path) -> None:
+    """Generate db browser SVG screenshots with warnings on failure."""
+    try:
+        generate_db_browser_screenshots(db_path)
+        print()
+    except Exception as e:
+        print(f"! Warning: DB browser screenshot generation failed: {e}")
         import traceback
 
         traceback.print_exc()

--- a/tests/unit/test_cli/test_db_browser_commands.py
+++ b/tests/unit/test_cli/test_db_browser_commands.py
@@ -1,0 +1,468 @@
+"""Unit tests for the db view and create-demo CLI commands."""
+
+from __future__ import annotations
+
+import sqlite3
+from argparse import Namespace
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+from sqlmodel import Session, create_engine
+
+from nexusLIMS.db.models import Instrument
+
+
+@pytest.fixture
+def demo_db(tmp_path) -> Path:
+    """Create a demo database with sample instruments."""
+    from nexusLIMS.tui.demo_helpers import create_demo_database
+
+    db_path = tmp_path / "demo.db"
+    create_demo_database(db_path)
+    return db_path
+
+
+@pytest.fixture
+def small_db(tmp_path) -> Path:
+    """Small SQLite database with 5 instruments for TUI tests."""
+    db_path = tmp_path / "test.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    Instrument.metadata.create_all(engine)
+    instruments = [
+        Instrument(
+            instrument_pid=f"Test-Instrument-{i:03d}",
+            api_url=f"https://nemo.example.com/api/tools/?id={i}",
+            calendar_url="https://nemo.example.com/calendar",
+            display_name=f"Test Instrument {i}",
+            location=f"Building {i}, Room 100",
+            property_tag=f"PRP-{i:05d}",
+            filestore_path=f"instrument_{i:03d}",
+            harvester="nemo",
+            timezone_str="America/New_York",
+        )
+        for i in range(1, 6)
+    ]
+    with Session(engine) as session:
+        session.add_all(instruments)
+        session.commit()
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# create-demo command
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDemoCommand:
+    """Tests for the ``nexuslims db create-demo`` command."""
+
+    def test_creates_db_at_default_path(self, tmp_path, monkeypatch):
+        from nexusLIMS.cli.migrate import _cli
+
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(_cli(), ["create-demo"])
+
+        assert result.exit_code == 0
+        assert (tmp_path / "nexuslims_demo.db").exists()
+        assert "✓" in result.output
+
+    def test_creates_db_at_explicit_path(self, tmp_path):
+        from nexusLIMS.cli.migrate import _cli
+
+        db_path = tmp_path / "my_demo.db"
+        runner = CliRunner()
+        result = runner.invoke(_cli(), ["create-demo", str(db_path)])
+
+        assert result.exit_code == 0
+        assert db_path.exists()
+
+    def test_populates_10_instruments(self, tmp_path):
+        from nexusLIMS.cli.migrate import _cli
+
+        db_path = tmp_path / "demo.db"
+        runner = CliRunner()
+        runner.invoke(_cli(), ["create-demo", str(db_path)])
+
+        conn = sqlite3.connect(db_path)
+        count = conn.execute("SELECT COUNT(*) FROM instruments").fetchone()[0]
+        conn.close()
+        assert count == 10
+
+    def test_refuses_to_overwrite_without_force(self, tmp_path):
+        from nexusLIMS.cli.migrate import _cli
+
+        db_path = tmp_path / "demo.db"
+        db_path.touch()
+        runner = CliRunner()
+        result = runner.invoke(_cli(), ["create-demo", str(db_path)])
+
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+
+    def test_force_flag_overwrites_existing(self, demo_db):
+        from nexusLIMS.cli.migrate import _cli
+
+        runner = CliRunner()
+        result = runner.invoke(_cli(), ["create-demo", str(demo_db), "--force"])
+
+        assert result.exit_code == 0, result.output
+        assert "✓" in result.output
+        # Confirm it's still a valid demo db
+        conn = sqlite3.connect(demo_db)
+        count = conn.execute("SELECT COUNT(*) FROM instruments").fetchone()[0]
+        conn.close()
+        assert count == 10
+
+    def test_help_text(self):
+        from nexusLIMS.cli.migrate import _cli
+
+        runner = CliRunner()
+        result = runner.invoke(_cli(), ["create-demo", "--help"])
+
+        assert result.exit_code == 0
+        assert "demo" in result.output.lower()
+        assert "PATH" in result.output
+        assert "--force" in result.output
+
+    def test_error_on_exception(self, tmp_path):
+        from nexusLIMS.cli.migrate import _cli
+
+        db_path = tmp_path / "demo.db"
+        with patch(
+            "nexusLIMS.tui.demo_helpers.create_demo_database",
+            side_effect=RuntimeError("disk full"),
+        ):
+            result = CliRunner().invoke(_cli(), ["create-demo", str(db_path)])
+
+        assert result.exit_code != 0
+        assert "Error" in result.output
+
+
+# ---------------------------------------------------------------------------
+# view command
+# ---------------------------------------------------------------------------
+
+
+class TestViewCommand:
+    """Tests for the ``nexuslims db view`` command."""
+
+    def test_help_text(self):
+        from nexusLIMS.cli.migrate import _cli
+
+        runner = CliRunner()
+        result = runner.invoke(_cli(), ["view", "--help"])
+
+        assert result.exit_code == 0
+        assert "read-only" in result.output.lower()
+
+    def test_exits_when_nx_db_path_not_set(self):
+        from nexusLIMS.cli.migrate import _cli
+
+        # load_dotenv uses override=False by default, so it will not overwrite
+        # the empty string we set via CliRunner's env parameter.
+        result = CliRunner().invoke(_cli(), ["view"], env={"NX_DB_PATH": ""})
+
+        assert result.exit_code != 0
+        assert "NX_DB_PATH" in result.output
+
+    def test_exits_when_db_does_not_exist(self, tmp_path):
+        from nexusLIMS.cli.migrate import _cli
+
+        missing = str(tmp_path / "missing.db")
+        result = CliRunner().invoke(_cli(), ["view"], env={"NX_DB_PATH": missing})
+
+        assert result.exit_code != 0
+        assert "does not exist" in result.output
+
+    def test_launches_app_when_db_exists(self, demo_db):
+        from nexusLIMS.cli.migrate import _cli
+
+        with patch("nexusLIMS.tui.apps.db_browser.NexusLIMSDBApp.run") as mock_run:
+            result = CliRunner().invoke(
+                _cli(), ["view"], env={"NX_DB_PATH": str(demo_db)}
+            )
+
+        assert result.exit_code == 0
+        mock_run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# NexusLIMSTableViewerPane — logic tests (no pilot)
+# ---------------------------------------------------------------------------
+
+
+class TestNexusLIMSTableViewerPaneLogic:
+    """Tests for pane helper methods that don't require a running app."""
+
+    def test_sort_label_unsorted(self):
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSTableViewerPane
+
+        pane = object.__new__(NexusLIMSTableViewerPane)
+        pane._sort_col = None
+        pane._sort_asc = True
+
+        assert pane._sort_label("instrument_pid") == "instrument_pid"
+
+    def test_sort_label_ascending(self):
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSTableViewerPane
+
+        pane = object.__new__(NexusLIMSTableViewerPane)
+        pane._sort_col = "instrument_pid"
+        pane._sort_asc = True
+
+        assert pane._sort_label("instrument_pid") == "instrument_pid ↑"
+
+    def test_sort_label_descending(self):
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSTableViewerPane
+
+        pane = object.__new__(NexusLIMSTableViewerPane)
+        pane._sort_col = "instrument_pid"
+        pane._sort_asc = False
+
+        assert pane._sort_label("instrument_pid") == "instrument_pid ↓"
+
+    def test_sort_label_other_column_unchanged(self):
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSTableViewerPane
+
+        pane = object.__new__(NexusLIMSTableViewerPane)
+        pane._sort_col = "instrument_pid"
+        pane._sort_asc = True
+
+        assert pane._sort_label("location") == "location"
+
+    def test_header_selected_sets_sort_col(self):
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSTableViewerPane
+
+        pane = object.__new__(NexusLIMSTableViewerPane)
+        pane._sort_col = None
+        pane._sort_asc = True
+        pane._load_table = MagicMock()
+
+        event = SimpleNamespace(column_key=SimpleNamespace(value="instrument_pid"))
+        pane._on_header_selected(event)
+
+        assert pane._sort_col == "instrument_pid"
+        assert pane._sort_asc is True
+        pane._load_table.assert_called_once()
+
+    def test_header_selected_second_click_reverses(self):
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSTableViewerPane
+
+        pane = object.__new__(NexusLIMSTableViewerPane)
+        pane._sort_col = "instrument_pid"
+        pane._sort_asc = True
+        pane._load_table = MagicMock()
+
+        event = SimpleNamespace(column_key=SimpleNamespace(value="instrument_pid"))
+        pane._on_header_selected(event)
+
+        assert pane._sort_col == "instrument_pid"
+        assert pane._sort_asc is False
+
+    def test_header_selected_third_click_clears(self):
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSTableViewerPane
+
+        pane = object.__new__(NexusLIMSTableViewerPane)
+        pane._sort_col = "instrument_pid"
+        pane._sort_asc = False
+        pane._load_table = MagicMock()
+
+        event = SimpleNamespace(column_key=SimpleNamespace(value="instrument_pid"))
+        pane._on_header_selected(event)
+
+        assert pane._sort_col is None
+        assert pane._sort_asc is True
+
+    def test_on_table_changed_blank_value_returns_early(self):
+        from textual.widgets._select import NULL as SELECT_BLANK
+
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSTableViewerPane
+
+        pane = object.__new__(NexusLIMSTableViewerPane)
+        pane._load_table = MagicMock()
+
+        event = SimpleNamespace(value=SELECT_BLANK)
+        pane._on_table_changed(event)
+
+        pane._load_table.assert_not_called()
+
+    def test_on_filter_changed_updates_text_and_reloads(self):
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSTableViewerPane
+
+        pane = object.__new__(NexusLIMSTableViewerPane)
+        pane._load_table = MagicMock()
+
+        event = SimpleNamespace(value="my_filter")
+        pane._on_filter_changed(event)
+
+        assert pane._filter_text == "my_filter"
+        pane._load_table.assert_called_once()
+
+    def test_header_selected_different_column_resets_to_asc(self):
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSTableViewerPane
+
+        pane = object.__new__(NexusLIMSTableViewerPane)
+        pane._sort_col = "instrument_pid"
+        pane._sort_asc = False
+        pane._load_table = MagicMock()
+
+        event = SimpleNamespace(column_key=SimpleNamespace(value="location"))
+        pane._on_header_selected(event)
+
+        assert pane._sort_col == "location"
+        assert pane._sort_asc is True
+
+
+# ---------------------------------------------------------------------------
+# NexusLIMSTableViewerPane — TUI integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestNexusLIMSTableViewerPaneTUI:
+    """TUI integration tests for NexusLIMSTableViewerPane."""
+
+    @pytest.mark.asyncio
+    async def test_app_launches(self, small_db):
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSDBApp
+
+        app = NexusLIMSDBApp(Namespace(filepath=str(small_db)))
+        async with app.run_test(size=(200, 50)) as pilot:
+            await pilot.pause(0.5)
+            assert app.is_running
+
+    @pytest.mark.asyncio
+    async def test_title_includes_db_path(self, small_db):
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSDBApp
+
+        app = NexusLIMSDBApp(Namespace(filepath=str(small_db)))
+        async with app.run_test(size=(200, 50)) as pilot:
+            await pilot.pause(0.5)
+            assert str(small_db) in app.title
+
+    @pytest.mark.asyncio
+    async def test_execute_sql_tab_absent(self, small_db):
+        from textual.widgets import TabbedContent
+
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSDBApp
+
+        app = NexusLIMSDBApp(Namespace(filepath=str(small_db)))
+        async with app.run_test(size=(200, 50)) as pilot:
+            await pilot.pause(0.5)
+            tc = app.query_one("#tabbed_ui", TabbedContent)
+            tab_labels = [str(pane._title) for pane in tc.query("TabPane")]
+            assert not any("SQL" in label for label in tab_labels)
+
+    @pytest.mark.asyncio
+    async def test_table_viewer_is_first_tab(self, small_db):
+        from textual.widgets import TabbedContent
+
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSDBApp
+
+        app = NexusLIMSDBApp(Namespace(filepath=str(small_db)))
+        async with app.run_test(size=(200, 50)) as pilot:
+            await pilot.pause(0.5)
+            tc = app.query_one("#tabbed_ui", TabbedContent)
+            panes = list(tc.query("TabPane"))
+            assert "Table Viewer" in str(panes[0]._title)
+
+    @pytest.mark.asyncio
+    async def test_table_viewer_loads_rows(self, small_db):
+        from textual.widgets import DataTable, Select
+
+        from nexusLIMS.tui.apps.db_browser import (
+            NexusLIMSDBApp,
+            NexusLIMSTableViewerPane,
+        )
+
+        app = NexusLIMSDBApp(Namespace(filepath=str(small_db)))
+        async with app.run_test(size=(200, 50)) as pilot:
+            await pilot.pause(0.5)
+            pane = app.query_one(NexusLIMSTableViewerPane)
+            # Explicitly select instruments (first table alphabetically may differ)
+            app.query_one("#table_names_select", Select).value = "instruments"
+            pane._load_table()
+            await pilot.pause(0.1)
+            dt = app.query_one("#sqlite_table_data", DataTable)
+            assert dt.row_count == 5
+
+    @pytest.mark.asyncio
+    async def test_filter_narrows_results(self, small_db):
+        from textual.widgets import DataTable
+
+        from nexusLIMS.tui.apps.db_browser import (
+            NexusLIMSDBApp,
+            NexusLIMSTableViewerPane,
+        )
+
+        app = NexusLIMSDBApp(Namespace(filepath=str(small_db)))
+        async with app.run_test(size=(200, 50)) as pilot:
+            await pilot.pause(0.5)
+            pane = app.query_one(NexusLIMSTableViewerPane)
+            # Set filter directly and reload
+            pane._filter_text = "001"
+            pane._load_table()
+            await pilot.pause(0.1)
+            dt = app.query_one("#sqlite_table_data", DataTable)
+            assert dt.row_count == 1
+
+    @pytest.mark.asyncio
+    async def test_load_table_with_sort_col(self, small_db):
+        from textual.widgets import DataTable, Select
+
+        from nexusLIMS.tui.apps.db_browser import (
+            NexusLIMSDBApp,
+            NexusLIMSTableViewerPane,
+        )
+
+        app = NexusLIMSDBApp(Namespace(filepath=str(small_db)))
+        async with app.run_test(size=(200, 50)) as pilot:
+            await pilot.pause(0.5)
+            pane = app.query_one(NexusLIMSTableViewerPane)
+            app.query_one("#table_names_select", Select).value = "instruments"
+            pane._sort_col = "instrument_pid"
+            pane._sort_asc = True
+            pane._load_table()
+            await pilot.pause(0.1)
+            dt = app.query_one("#sqlite_table_data", DataTable)
+            assert dt.row_count == 5
+
+    @pytest.mark.asyncio
+    async def test_update_ui_notifies_when_db_missing(self, small_db):
+        from nexusLIMS.tui.apps.db_browser import NexusLIMSDBApp
+
+        app = NexusLIMSDBApp(Namespace(filepath=str(small_db)))
+        async with app.run_test(size=(200, 50)) as pilot:
+            await pilot.pause(0.5)
+            await app.update_ui("/nonexistent/path/missing.db")
+            await pilot.pause(0.1)
+            # App should still be running — notify() was called, not exit
+            assert app.is_running
+
+    @pytest.mark.asyncio
+    async def test_filter_no_results_shows_blank_row(self, small_db):
+        from textual.widgets import DataTable
+
+        from nexusLIMS.tui.apps.db_browser import (
+            NexusLIMSDBApp,
+            NexusLIMSTableViewerPane,
+        )
+
+        app = NexusLIMSDBApp(Namespace(filepath=str(small_db)))
+        async with app.run_test(size=(200, 50)) as pilot:
+            await pilot.pause(0.5)
+            pane = app.query_one(NexusLIMSTableViewerPane)
+            pane._filter_text = "ZZZNOMATCH"
+            pane._load_table()
+            await pilot.pause(0.1)
+            dt = app.query_one("#sqlite_table_data", DataTable)
+            assert dt.row_count == 1  # one blank placeholder row
+
+
+pytestmark = pytest.mark.database

--- a/uv.lock
+++ b/uv.lock
@@ -1677,6 +1677,7 @@ dependencies = [
     { name = "rich" },
     { name = "scikit-learn" },
     { name = "sqlmodel" },
+    { name = "squall-sql" },
     { name = "textual" },
     { name = "tzlocal" },
 ]
@@ -1737,6 +1738,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0.0" },
     { name = "scikit-learn", specifier = ">=1.2.0,<2.0.0" },
     { name = "sqlmodel", specifier = ">=0.0.31" },
+    { name = "squall-sql", specifier = ">=0.1.8" },
     { name = "textual", specifier = ">=8.0.0" },
     { name = "tzlocal", specifier = ">=5.3.1" },
 ]
@@ -3253,6 +3255,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/b8/e7cd6def4a773f25d6e29ffce63ccbfd6cf9488b804ab6fb9b80d334b39d/sqlmodel-0.0.31.tar.gz", hash = "sha256:2d41a8a9ee05e40736e2f9db8ea28cbfe9b5d4e5a18dd139e80605025e0c516c", size = 94952, upload-time = "2025-12-28T12:35:01.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/72/5aa5be921800f6418a949a73c9bb7054890881143e6bc604a93d228a95a3/sqlmodel-0.0.31-py3-none-any.whl", hash = "sha256:6d946d56cac4c2db296ba1541357cee2e795d68174e2043cd138b916794b1513", size = 27093, upload-time = "2025-12-28T12:35:00.108Z" },
+]
+
+[[package]]
+name = "squall-sql"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rich" },
+    { name = "sqlalchemy" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/6f/288bb063c1755774b95830e95bd89d3459204ad1b962e5efee50f67d4c58/squall_sql-0.1.8.tar.gz", hash = "sha256:a6c0adba3e6919e3fb2c05d7f9cce8260b6d8cc1ad5f71cb08ea5ccc7b70d974", size = 9269, upload-time = "2025-03-11T18:18:22.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/a6/f8802ba2e8cae7a345f488b21d821d8e3f99a35b64dcbc428a5e71e390f8/squall_sql-0.1.8-py3-none-any.whl", hash = "sha256:d9a932e3afdce4122ce64e9462005596d84d4ac5a3146bb184cabb51216be907", size = 11705, upload-time = "2025-03-11T18:18:21.419Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #80

## Summary

- Adds `nexuslims db view` — a read-only, Squall-powered TUI for browsing the NexusLIMS SQLite database directly from the terminal
- Adds `nexuslims db create-demo` — populates a demo database with 10 sample instruments, making it easy for new users to explore the system
- The TUI extends Squall's `SQLiteClientApp` with: the "Open Database" button hidden, the "Execute SQL" tab removed (to prevent accidental writes), and a custom `NexusLIMSTableViewerPane` with a live filter input and click-to-sort column headers — all via parameterised SQL so they compose safely

## Changes

- `nexusLIMS/tui/apps/db_browser.py` — `NexusLIMSDBApp` and `NexusLIMSTableViewerPane` TUI components
- `nexusLIMS/cli/migrate.py` — `view` and `create-demo` subcommands added to the `db` group
- `nexusLIMS/cli/main.py` — CLI entrypoint updated
- `docs/user_guide/cli_reference.md` — updated command reference
- `docs/conf.py` — added `squall` to nitpick ignore list
- `pyproject.toml` / `uv.lock` — added `squall` dependency
- `scripts/generate_tui_demos.py` — demo generation support for docs
- `docs/changes/80.feature.md` — changelog entry

## Test plan

- [x] `uv run pytest tests/unit/test_cli/test_db_browser_commands.py -v` — all unit and TUI integration tests pass
- [x] `nexuslims db create-demo` creates `nexuslims_demo.db` in the current directory
- [x] `nexuslims db view` with `NX_DB_PATH` pointing to the demo db opens the TUI browser
- [x] Filter input narrows displayed rows; column header clicks cycle through asc/desc/unsorted
- [x] "Execute SQL" tab is absent; "Open Database" button is hidden