### PR TITLE
Fix CDCS REST API compatibility with NexusLIMS-CDCS 3.20.x

### DIFF
--- a/docs/changes/91.misc.md
+++ b/docs/changes/91.misc.md
@@ -1,0 +1,1 @@
+Updated CDCS REST API endpoint URLs to include trailing slashes, required for compatibility with NexusLIMS-CDCS 3.20.x. Added a [version compatibility reference page](https://datasophos.github.io/NexusLIMS/2.6.1/reference/compatibility.html) documenting which NexusLIMS-CDCS version is required for each NexusLIMS release.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -303,6 +303,7 @@ exclude_patterns = [
     "dev_scripts",
     "_ext/README.md",
     "reference/labarchives_api_docs",
+    "**/._*",  # macOS resource fork files
 ]
 
 # Keep warnings as “system message” paragraphs in the built documents.

--- a/docs/frontend_guide/configuration.md
+++ b/docs/frontend_guide/configuration.md
@@ -28,7 +28,7 @@ Never commit `.env` to version control - it contains secrets!
 | Variable | Description | Dev Default | Prod Example |
 |----------|-------------|-------------|--------------|
 | `COMPOSE_PROJECT_NAME` | Docker Compose project name | `nexuslims_dev` | `nexuslims_prod` |
-| `IMAGE_VERSION` | Docker image version tag | `latest` | `3.18.0` |
+| `IMAGE_VERSION` | Docker image version tag | `latest` | `3.20.0-nx0` (see {ref}`compatibility`) |
 
 ### Domain Configuration
 

--- a/docs/frontend_guide/overview.md
+++ b/docs/frontend_guide/overview.md
@@ -97,6 +97,12 @@ NexusLIMS-CDCS/
 └── nexuslims_overrides/          # NexusLIMS-specific customizations
 ```
 
+## Version Compatibility
+
+NexusLIMS-CDCS and the NexusLIMS backend must be kept in sync. See the
+{ref}`Version Compatibility <compatibility>` reference for the full matrix of which
+NexusLIMS-CDCS versions are compatible with each NexusLIMS backend release.
+
 ## Related Resources
 
 - **Repository**: [https://github.com/datasophos/NexusLIMS-CDCS](https://github.com/datasophos/NexusLIMS-CDCS)

--- a/docs/frontend_guide/production.md
+++ b/docs/frontend_guide/production.md
@@ -486,7 +486,7 @@ Restart Docker: `sudo systemctl restart docker`
    ```bash
    cd /opt/nexuslims/NexusLIMS-CDCS
    git fetch
-   git checkout v3.19.0  # or desired version
+   git checkout v3.20.0-nx0  # or desired version — see {ref}`compatibility` for version requirements
    ```
 
 3. **Review changelog** for breaking changes
@@ -513,7 +513,7 @@ If upgrade fails:
 
 ```bash
 dc-prod down
-git checkout v3.18.0  # Previous version
+git checkout v3.20.0-nx0  # or whichever version matches your NexusLIMS backend — see {ref}`compatibility`
 cd deployment
 dc-prod build
 dc-prod up -d

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,6 +6,7 @@ Technical reference documentation for NexusLIMS.
 ```{toctree}
 :maxdepth: 2
 
+reference/compatibility
 reference/changelog
 reference/api
 reference/NEMO_Reference

--- a/docs/reference/compatibility.md
+++ b/docs/reference/compatibility.md
@@ -1,0 +1,24 @@
+(compatibility)=
+# Version Compatibility
+
+This page documents the compatibility between NexusLIMS (backend) and
+[NexusLIMS-CDCS](https://github.com/datasophos/NexusLIMS-CDCS) (frontend) versions.
+
+```{important}
+Using mismatched versions may cause upload failures or API errors. Always check this
+table when upgrading either component.
+```
+
+## NexusLIMS-CDCS Version Tags
+
+NexusLIMS-CDCS release tags follow the format `{base_cdcs_version}-nx{n}`, where the
+`-nx{n}` suffix distinguishes NexusLIMS-specific releases from the upstream MDCS version.
+For example, `3.20.0-nx0` is the first NexusLIMS release based on CDCS 3.20.0.
+
+## NexusLIMS / NexusLIMS-CDCS Compatibility Matrix
+
+| NexusLIMS Version | NexusLIMS-CDCS Version | Notes |
+|-------------------|------------------------|-------|
+| 2.6.1             | `3.20.x-nx0`           | CDCS REST API now requires trailing slashes on all endpoints; not backwards compatible with 3.18.x |
+| 2.0 -- 2.6.0      | `3.18.0-nx0`           | |
+| 1.x               | 2.x                    | Original NIST-era releases |

--- a/nexusLIMS/exporters/destinations/cdcs.py
+++ b/nexusLIMS/exporters/destinations/cdcs.py
@@ -191,7 +191,7 @@ class CDCSDestination:
             If authentication fails
         """
         endpoint = urljoin(
-            str(settings.NX_CDCS_URL), "rest/template-version-manager/global"
+            str(settings.NX_CDCS_URL), "rest/template-version-manager/global/"
         )
         r = nexus_req(endpoint, "GET", token_auth=settings.NX_CDCS_TOKEN)
 
@@ -215,7 +215,7 @@ class CDCSDestination:
         AuthenticationError
             If authentication fails
         """
-        endpoint = urljoin(str(settings.NX_CDCS_URL), "rest/workspace/read_access")
+        endpoint = urljoin(str(settings.NX_CDCS_URL), "rest/workspace/read_access/")
         r = nexus_req(endpoint, "GET", token_auth=settings.NX_CDCS_TOKEN)
 
         if r.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):

--- a/nexusLIMS/extractors/__init__.py
+++ b/nexusLIMS/extractors/__init__.py
@@ -683,7 +683,15 @@ def create_preview(  # noqa: PLR0911, PLR0912, PLR0915
     _logger.info("Generating HyperSpy preview: %s", preview_fname)
     preview_fname.parent.mkdir(parents=True, exist_ok=True)
     s.compute(show_progressbar=False)
-    sig_to_thumbnail(s, out_path=preview_fname)
+    try:
+        sig_to_thumbnail(s, out_path=preview_fname)
+    except Exception:  # pylint: disable=broad-exception-caught
+        _logger.warning(
+            "Legacy HyperSpy preview generation failed for %s. "
+            "Using placeholder image for preview.",
+            fname,
+        )
+        shutil.copyfile(PLACEHOLDER_PREVIEW, preview_fname)
 
     return preview_fname
 

--- a/nexusLIMS/utils/cdcs.py
+++ b/nexusLIMS/utils/cdcs.py
@@ -96,7 +96,7 @@ def get_workspace_id() -> int:
     """
     # assuming there's only one workspace for this user (that is the public
     # workspace)
-    endpoint = urljoin(get_cdcs_url(), "rest/workspace/read_access")
+    endpoint = urljoin(get_cdcs_url(), "rest/workspace/read_access/")
     r = nexus_req(endpoint, "GET", token_auth=settings.NX_CDCS_TOKEN)
     if r.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
         msg = (
@@ -124,7 +124,7 @@ def get_template_id() -> str:
         If authentication to CDCS fails
     """
     # get the current template (XSD) id value:
-    endpoint = urljoin(get_cdcs_url(), "rest/template-version-manager/global")
+    endpoint = urljoin(get_cdcs_url(), "rest/template-version-manager/global/")
     r = nexus_req(endpoint, "GET", token_auth=settings.NX_CDCS_TOKEN)
     if r.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
         msg = (
@@ -150,7 +150,7 @@ def delete_record(record_id: str):
         The REST response returned from the CDCS instance after attempting
         the delete operation
     """
-    endpoint = urljoin(get_cdcs_url(), f"rest/data/{record_id}")
+    endpoint = urljoin(get_cdcs_url(), f"rest/data/{record_id}/")
     response = nexus_req(endpoint, "DELETE", token_auth=settings.NX_CDCS_TOKEN)
     if response.status_code != HTTPStatus.NO_CONTENT:
         # anything other than 204 status means something went wrong

--- a/tests/integration/test_cdcs_integration.py
+++ b/tests/integration/test_cdcs_integration.py
@@ -225,7 +225,7 @@ class TestCdcsRecordRetrieval:
         from nexusLIMS import config
         from nexusLIMS.utils.network import nexus_req
 
-        endpoint = urljoin(cdcs_url, f"rest/data/{record_id}")
+        endpoint = urljoin(cdcs_url, f"rest/data/{record_id}/")
         response = nexus_req(endpoint, "GET", token_auth=config.settings.NX_CDCS_TOKEN)
 
         # Verify retrieval was successful
@@ -253,7 +253,7 @@ class TestCdcsRecordRetrieval:
         from nexusLIMS import config
         from nexusLIMS.utils.network import nexus_req
 
-        endpoint = urljoin(cdcs_url, f"rest/data/{record_id}")
+        endpoint = urljoin(cdcs_url, f"rest/data/{record_id}/")
         response = nexus_req(endpoint, "GET", token_auth=config.settings.NX_CDCS_TOKEN)
 
         assert response.status_code == HTTPStatus.OK

--- a/tests/unit/test_extractors/test_extractor_module.py
+++ b/tests/unit/test_extractors/test_extractor_module.py
@@ -1228,6 +1228,64 @@ class TestExtractorModule:
             if result and result.exists():
                 result.unlink()
 
+    def test_create_preview_hyperspy_sig_to_thumbnail_raises(self, tmp_path):
+        """Test fallback to placeholder when sig_to_thumbnail raises an exception.
+
+        When sig_to_thumbnail fails during legacy HyperSpy preview generation,
+        the placeholder image should be copied to the preview path instead.
+        """
+        import unittest.mock
+        from contextlib import ExitStack
+
+        import hyperspy.api as hs
+        import numpy as np
+
+        from nexusLIMS.extractors import PLACEHOLDER_PREVIEW, create_preview
+
+        signal = hs.signals.Signal2D(np.random.random((10, 10)))
+        signal.metadata.General.title = "Test Signal"
+        signal.metadata.General.original_filename = "test.dm3"
+
+        def mock_hs_load(fname, **kwargs):
+            signal.compute = unittest.mock.Mock()
+            return signal
+
+        mock_reg_instance = unittest.mock.Mock()
+        mock_reg_instance.get_preview_generator.return_value = None
+
+        preview_path = tmp_path / "preview.thumb.png"
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                unittest.mock.patch(
+                    "nexusLIMS.extractors.hs.load", side_effect=mock_hs_load
+                )
+            )
+            stack.enter_context(
+                unittest.mock.patch(
+                    "nexusLIMS.extractors.sig_to_thumbnail",
+                    side_effect=RuntimeError("thumbnail generation failed"),
+                )
+            )
+            stack.enter_context(
+                unittest.mock.patch(
+                    "nexusLIMS.extractors.replace_instrument_data_path",
+                    return_value=preview_path,
+                )
+            )
+            stack.enter_context(
+                unittest.mock.patch(
+                    "nexusLIMS.extractors.get_registry",
+                    return_value=mock_reg_instance,
+                )
+            )
+
+            result = create_preview(fname=tmp_path / "test.dm3", overwrite=True)
+
+        assert result == preview_path
+        assert result.exists()
+        assert result.read_bytes() == PLACEHOLDER_PREVIEW.read_bytes()
+
     def test_parse_metadata_extractor_returns_none(self, monkeypatch, tmp_path):
         """Test parse_metadata when extractor returns None.
 

--- a/uv.lock
+++ b/uv.lock
@@ -842,7 +842,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/cb/48e964c452ca2b92175a9b2dca037a553036cb053ba69e284650ce755f13/greenlet-3.3.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e29f3018580e8412d6aaf5641bb7745d38c85228dacf51a73bd4e26ddf2a6a8e", size = 274908, upload-time = "2025-12-04T14:23:26.435Z" },
     { url = "https://files.pythonhosted.org/packages/28/da/38d7bff4d0277b594ec557f479d65272a893f1f2a716cad91efeb8680953/greenlet-3.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a687205fb22794e838f947e2194c0566d3812966b41c78709554aa883183fb62", size = 577113, upload-time = "2025-12-04T14:50:05.493Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f2/89c5eb0faddc3ff014f1c04467d67dee0d1d334ab81fadbf3744847f8a8a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4243050a88ba61842186cb9e63c7dfa677ec146160b0efd73b855a3d9c7fcf32", size = 590338, upload-time = "2025-12-04T14:57:41.136Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d7/db0a5085035d05134f8c089643da2b44cc9b80647c39e93129c5ef170d8f/greenlet-3.3.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:670d0f94cd302d81796e37299bcd04b95d62403883b24225c6b5271466612f45", size = 601098, upload-time = "2025-12-04T15:07:11.898Z" },
     { url = "https://files.pythonhosted.org/packages/dc/a6/e959a127b630a58e23529972dbc868c107f9d583b5a9f878fb858c46bc1a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb3a8ec3db4a3b0eb8a3c25436c2d49e3505821802074969db017b87bc6a948", size = 590206, upload-time = "2025-12-04T14:26:01.254Z" },
     { url = "https://files.pythonhosted.org/packages/48/60/29035719feb91798693023608447283b266b12efc576ed013dd9442364bb/greenlet-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2de5a0b09eab81fc6a382791b995b1ccf2b172a9fec934747a7a23d2ff291794", size = 1550668, upload-time = "2025-12-04T15:04:22.439Z" },
     { url = "https://files.pythonhosted.org/packages/0a/5f/783a23754b691bfa86bd72c3033aa107490deac9b2ef190837b860996c9f/greenlet-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4449a736606bd30f27f8e1ff4678ee193bc47f6ca810d705981cfffd6ce0d8c5", size = 1615483, upload-time = "2025-12-04T14:27:28.083Z" },
@@ -850,7 +849,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
     { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
     { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
-    { url = "https://files.pythonhosted.org/packages/77/cb/43692bcd5f7a0da6ec0ec6d58ee7cddb606d055ce94a62ac9b1aa481e969/greenlet-3.3.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c024b1e5696626890038e34f76140ed1daf858e37496d33f2af57f06189e70d7", size = 622297, upload-time = "2025-12-04T15:07:13.552Z" },
     { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
     { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },
@@ -1654,7 +1652,7 @@ wheels = [
 
 [[package]]
 name = "nexuslims"
-version = "2.5.2.dev0"
+version = "2.6.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
Closes #91

## Summary

- Add trailing slashes to all CDCS REST API endpoint URLs (`cdcs.py`, `CDCSDestination`, and integration tests), required by NexusLIMS-CDCS 3.20.x (Django `APPEND_SLASH=True` returns 500 on DELETE/PATCH without trailing slash)
- Wrap legacy HyperSpy `sig_to_thumbnail` call in `try/except` to fall back to a placeholder image on failure rather than raising
- Add `docs/reference/compatibility.md` with a NexusLIMS / NexusLIMS-CDCS version matrix and explanation of the `-nx{n}` tag format; cross-reference from the frontend guide overview, production, and configuration pages
- Exclude macOS resource fork files (`._*`) from Sphinx doc builds to fix spurious `toc.not_included` warnings
- Add changelog fragment `91.misc.md`

## Test plan

- [x] Unit test `test_create_preview_hyperspy_sig_to_thumbnail_raises` covers the new fallback path (lines 688-694 of `extractors/__init__.py`)
- [x] Integration tests updated to use trailing-slash endpoints — verify against a running NexusLIMS-CDCS 3.20.x instance
- [x] Docs build cleanly with no `toc.not_included` warnings for `._*` files