### PR TITLE
fix: apply percentile contrast stretch for 16-bit TIFF previews

### DIFF
--- a/docs/changes/99.bugfix.md
+++ b/docs/changes/99.bugfix.md
@@ -1,0 +1,1 @@
+Fixed blank preview thumbnails for 16-bit TIFF images by applying a 2nd--98th percentile contrast stretch before converting to 8-bit.

--- a/nexusLIMS/extractors/plugins/preview_generators/image_preview.py
+++ b/nexusLIMS/extractors/plugins/preview_generators/image_preview.py
@@ -1,11 +1,11 @@
 """Image file preview generator."""
 
 import logging
-import shutil
 from pathlib import Path
 from typing import ClassVar, Tuple
 
 import matplotlib.pyplot as plt
+import numpy as np
 from PIL import Image, UnidentifiedImageError
 
 from nexusLIMS.extractors.base import ExtractionContext
@@ -72,12 +72,27 @@ def image_to_square_thumbnail(f: Path, out_path: Path, output_size: int) -> bool
     bool
         Whether a preview was generated
     """
-    shutil.copy(f, out_path)
     try:
+        image = Image.open(f)
+        # For high-bit-depth images (e.g. uint16 TIFFs from scientific instruments),
+        # apply percentile contrast stretching so the full 8-bit range is used.
+        # Without this, low-contrast features (e.g. ECCI patterns) disappear entirely.
+        if image.mode in ("I", "I;16", "I;16B") or (
+            hasattr(image, "mode") and "16" in str(image.mode)
+        ):
+            arr = np.array(image, dtype=np.float32)
+            lo, hi = np.nanpercentile(arr, [2, 98])
+            if hi > lo:
+                arr = np.clip((arr - lo) / (hi - lo) * 255, 0, 255).astype(np.uint8)
+            else:
+                arr = np.zeros_like(arr, dtype=np.uint8)
+            image = Image.fromarray(arr, mode="L")
+        image.save(out_path)
         _pad_to_square(out_path, output_size)
     except UnidentifiedImageError as exc:
         _logger.warning("no preview generated; PIL error text: %s", str(exc))
-        out_path.unlink()
+        if out_path.exists():
+            out_path.unlink()
         return False
 
     return True

--- a/tests/unit/test_extractors/test_thumbnail_generator.py
+++ b/tests/unit/test_extractors/test_thumbnail_generator.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from hyperspy.io import load as hs_load
 from hyperspy.misc.utils import stack as hs_stack
+from PIL import Image as PILImage
 
 from nexusLIMS.extractors.plugins.preview_generators import (
     hyperspy_preview,
@@ -383,6 +384,41 @@ class TestThumbnailGenerator:  # pylint: disable=too-many-public-methods
         )
         image_to_square_thumbnail(image_thumb_source_tif, output_path, 500)
         assert_images_equal(baseline_thumb_tif, output_path)
+
+    def test_16bit_tif_contrast_stretch(self, tmp_path, output_path):
+        """Test 16-bit TIFFs get percentile contrast stretching applied.
+
+        Without contrast stretching, PIL would naively truncate uint16 values to
+        8-bit (e.g. 40000 becomes ~156 via 40000/256). With the stretch applied,
+        the bright pixels are mapped to 255, confirming the stretch ran.
+        """
+        arr = np.zeros((100, 100), dtype=np.uint16)
+        arr[10:90, 10:90] = 40000  # bright outer region
+        arr[20:80, 20:80] = 1000  # intermediate inner region
+        tif_path = tmp_path / "test_16bit.tif"
+        PILImage.fromarray(arr).save(tif_path)
+
+        result = image_to_square_thumbnail(tif_path, output_path, 500)
+
+        assert result is True
+        assert output_path.exists()
+        out_arr = np.array(PILImage.open(output_path).convert("L"))
+        # Without stretch, 40000 would truncate to ~156; with stretch it maps to 255
+        assert out_arr.max() == 255
+        # Intermediate values (1000) should appear as non-zero after stretching
+        assert out_arr.mean() > 1
+
+    def test_unidentified_image_removes_partial_output(
+        self, unreadable_image_file, output_path
+    ):
+        """Test that an existing output file is removed on UnidentifiedImageError."""
+        output_path.write_bytes(b"partial output")
+        assert output_path.exists()
+
+        result = image_to_square_thumbnail(unreadable_image_file, output_path, 500)
+
+        assert result is False
+        assert not output_path.exists()
 
     def test_assert_image_fail(self, image_thumb_source_tif, quanta_test_file):
         """Sanity check that for images that are not the same."""


### PR DESCRIPTION
## Summary

- Detects 16-bit TIFF modes (`"I"`, `"I;16"`, `"I;16B"`)
- Applies 2nd-98th percentile contrast stretch and converts to 8-bit before generating thumbnail
- Fixes blank/near-blank previews for scientific images like ECCI patterns

## Test plan

- [ ] `uv run pytest --mpl --mpl-baseline-path=tests/files/figs tests/unit/test_extractors/`