### PR TITLE
fix: tofwerk preview generator OOM error and depth-plot shape mismatch

### DIFF
--- a/nexusLIMS/extractors/plugins/preview_generators/tofwerk_pfib_preview.py
+++ b/nexusLIMS/extractors/plugins/preview_generators/tofwerk_pfib_preview.py
@@ -257,6 +257,39 @@ def _compute_tic_from_eventlist(el: h5py.Dataset) -> tuple[np.ndarray, np.ndarra
     return tic_map, depth_counts
 
 
+def _compute_peak_aggregates_chunked(
+    pk_ds: h5py.Dataset,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Compute per-mass sums, spatial maps, and depth profiles from PeakData.
+
+    Reads one write at a time to avoid loading the full dataset into memory.
+    A full load of PeakData can easily exceed 30 GiB for large acquisitions.
+
+    Parameters
+    ----------
+    pk_ds
+        PeakData HDF5 dataset of shape (nwrites, ny, nx, npeaks), float32
+
+    Returns
+    -------
+    per_mass : ndarray of shape (npeaks,)
+    spatial : ndarray of shape (ny, nx, npeaks)
+    depth_prof : ndarray of shape (nwrites, npeaks)
+    """
+    nwrites, ny, nx, npeaks = pk_ds.shape
+    per_mass = np.zeros(npeaks, dtype=np.float64)
+    spatial = np.zeros((ny, nx, npeaks), dtype=np.float64)
+    depth_prof = np.zeros((nwrites, npeaks), dtype=np.float64)
+    for w in range(nwrites):
+        chunk = pk_ds[w].astype(np.float64)  # shape (ny, nx, npeaks)
+        spatial += chunk
+        write_sum = chunk.sum(axis=(0, 1))  # shape (npeaks,)
+        depth_prof[w] = write_sum
+        per_mass += write_sum
+    return per_mass, spatial, depth_prof
+
+
 # ---------------------------------------------------------------------------
 # Preview generator class
 # ---------------------------------------------------------------------------
@@ -378,7 +411,9 @@ def _generate_preview(  # noqa: PLR0912, PLR0915
         nbr_writes = int(_read_attr_scalar(f, "NbrWrites", 0))
 
         if has_peaks:
-            peak_data = f["PeakData/PeakData"][:]
+            pk_ds = f["PeakData/PeakData"]
+            nwrites_pk, ny, nx, npeaks = pk_ds.shape
+            per_mass, spatial, depth_prof = _compute_peak_aggregates_chunked(pk_ds)
             peak_table = f["PeakData/PeakTable"][:]
         else:
             el = f["FullSpectra/EventList"]
@@ -396,11 +431,7 @@ def _generate_preview(  # noqa: PLR0912, PLR0915
 
     # Derived arrays for opened files
     if has_peaks:
-        nwrites_pk, ny, nx, npeaks = peak_data.shape
-        per_mass = peak_data.sum(axis=(0, 1, 2))
-        spatial = peak_data.sum(axis=0)
         tic_map = spatial.sum(axis=2)
-        depth_prof = peak_data.sum(axis=(1, 2))
 
         peak_masses = np.array([float(peak_table[i]["mass"]) for i in range(npeaks)])
         above_min = np.where(peak_masses >= min_mass)[0]
@@ -431,7 +462,7 @@ def _generate_preview(  # noqa: PLR0912, PLR0915
         writes = np.arange(nwrites_pk) + 1
         mode_str = "Processed"
     else:
-        writes = np.arange(nbr_writes) + 1
+        writes = np.arange(len(depth_counts)) + 1
         mode_str = "Raw"
 
     # Annotate top peaks in sum spectrum (spaced >= 2 Da apart)

--- a/tests/unit/test_extractors/test_tofwerk_pfib.py
+++ b/tests/unit/test_extractors/test_tofwerk_pfib.py
@@ -10,6 +10,7 @@ import numpy as np
 from nexusLIMS.extractors.base import ExtractionContext
 from nexusLIMS.extractors.plugins.preview_generators.tofwerk_pfib_preview import (
     TofwerkPfibPreviewGenerator,
+    _compute_peak_aggregates_chunked,
     _depth_plot_style,
     _norm_channel,
     _tic_display_limits,
@@ -519,3 +520,95 @@ class TestPrivateHelpers:
         with h5py.File(p, "r") as f:
             _extract_fib_params(f, nx_meta)
         assert nx_meta == {}  # nothing was added
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for client-reported bugs
+# ---------------------------------------------------------------------------
+
+
+class TestComputePeakAggregatesChunked:
+    """Regression tests for _compute_peak_aggregates_chunked (see issue #104).
+
+    Previously, _generate_preview loaded PeakData/PeakData[:] in one shot,
+    which caused an OOM error for large acquisitions (e.g. 500x256x256x259
+    float32 = 31.6 GiB).  The fix reads one write at a time.
+    """
+
+    def test_aggregates_match_full_load(self, tmp_path):
+        """Chunked aggregates must match the equivalent full-array reductions."""
+        nwrites, ny, nx, npeaks = 4, 6, 6, 8
+        rng = np.random.default_rng(42)
+        data = rng.exponential(10, (nwrites, ny, nx, npeaks)).astype(np.float32)
+
+        p = tmp_path / "peak_data.h5"
+        with h5py.File(p, "w") as f:
+            f.create_dataset("PeakData", data=data)
+
+        with h5py.File(p, "r") as f:
+            per_mass, spatial, depth_prof = _compute_peak_aggregates_chunked(
+                f["PeakData"]
+            )
+
+        expected_per_mass = data.sum(axis=(0, 1, 2)).astype(np.float64)
+        expected_spatial = data.sum(axis=0).astype(np.float64)
+        expected_depth_prof = data.sum(axis=(1, 2)).astype(np.float64)
+
+        np.testing.assert_allclose(per_mass, expected_per_mass, rtol=1e-5)
+        np.testing.assert_allclose(spatial, expected_spatial, rtol=1e-5)
+        np.testing.assert_allclose(depth_prof, expected_depth_prof, rtol=1e-5)
+
+    def test_output_shapes(self, tmp_path):
+        """Returned arrays have the expected shapes."""
+        nwrites, ny, nx, npeaks = 3, 5, 7, 4
+        data = np.ones((nwrites, ny, nx, npeaks), dtype=np.float32)
+
+        p = tmp_path / "peak_data_shapes.h5"
+        with h5py.File(p, "w") as f:
+            f.create_dataset("PeakData", data=data)
+
+        with h5py.File(p, "r") as f:
+            per_mass, spatial, depth_prof = _compute_peak_aggregates_chunked(
+                f["PeakData"]
+            )
+
+        assert per_mass.shape == (npeaks,)
+        assert spatial.shape == (ny, nx, npeaks)
+        assert depth_prof.shape == (nwrites, npeaks)
+
+
+class TestNbrWritesMismatchRegression:
+    """Regression test for NbrWrites attribute off-by-one vs EventList shape (#104).
+
+    Previously, the depth-profile x-axis (writes) was built from the NbrWrites
+    HDF5 root attribute while depth_counts came from the actual EventList shape.
+    When these differed by one, matplotlib raised:
+      ValueError: x and y must have same first dimension
+    """
+
+    def test_generate_succeeds_when_nbr_writes_exceeds_eventlist(
+        self, tmp_path, tofwerk_raw_file
+    ):
+        """Preview generates successfully when NbrWrites > EventList.shape[0]."""
+        # Patch NbrWrites to be one more than the actual EventList depth dimension
+        with h5py.File(tofwerk_raw_file, "r+") as f:
+            actual_nwrites = f["FullSpectra/EventList"].shape[0]
+            f.attrs["NbrWrites"] = np.int32(actual_nwrites + 1)
+
+        out = tmp_path / "preview_mismatch.png"
+        gen = TofwerkPfibPreviewGenerator()
+        assert gen.generate(_make_context(tofwerk_raw_file), out) is True
+        assert out.exists()
+
+    def test_generate_succeeds_when_nbr_writes_less_than_eventlist(
+        self, tmp_path, tofwerk_raw_file
+    ):
+        """Preview generates successfully when NbrWrites < EventList.shape[0]."""
+        with h5py.File(tofwerk_raw_file, "r+") as f:
+            actual_nwrites = f["FullSpectra/EventList"].shape[0]
+            f.attrs["NbrWrites"] = np.int32(max(1, actual_nwrites - 1))
+
+        out = tmp_path / "preview_mismatch_under.png"
+        gen = TofwerkPfibPreviewGenerator()
+        assert gen.generate(_make_context(tofwerk_raw_file), out) is True
+        assert out.exists()


### PR DESCRIPTION
Fixes #104.

## Summary

- **OOM fix**: Replace full `PeakData/PeakData[:]` load with `_compute_peak_aggregates_chunked()`, which reads one write at a time (matching the existing `_compute_tic_from_eventlist()` pattern) and accumulates only the three needed aggregates (`per_mass`, `spatial`, `depth_prof`). Peak memory for a 500×256×256×259 float32 acquisition drops from ~32 GiB to ~135 MB.
- **Shape mismatch fix**: Derive the depth-profile x-axis (`writes`) from `len(depth_counts)` (actual `EventList` shape) instead of the `NbrWrites` root HDF5 attribute, which can disagree by one and caused `ValueError: x and y must have same first dimension`.

## Test plan

- [x] All 43 tofwerk unit tests pass (`uv run pytest -k tofwerk tests/unit/`)
- [x] Verify preview generates successfully for a large pre-processed file (>3 GB, shape ~500×256×256×259)
- [x] Verify preview generates successfully for a small raw file where `NbrWrites` attribute differs from `EventList.shape[0]`