### PR TITLE
fix: <sample> id attribute and release script guards (#108)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -6,12 +6,28 @@ description: Prepare a NexusLIMS release with changelog review and upgrade instr
 
 # NexusLIMS Release Preparation
 
+## Pre-flight: Branch Guard
+
+Before doing anything else, run:
+
+```bash
+git branch --show-current
+```
+
+**If the result is not `main`, stop immediately** and tell the user:
+
+> Cannot release from branch `<branch>`. Releases must be cut from `main`. Merge all feature branches into main first, then run `/release` again.
+
+Do not proceed past this point until the branch is `main`.
+
+---
+
 ## Current State
 
 Use your tools to gather the following information before proceeding:
 
 1. **Current version:** Read `pyproject.toml` and extract the `version = "..."` line.
-2. **Current branch:** Run `git branch --show-current`.
+2. **Current branch:** Run `git branch --show-current` (already confirmed `main` above).
 3. **Pending changelog fragments:** Use Glob to find all `docs/changes/*.md` files (exclude `README.md`), then Read each one and display its filename and contents.
 4. **Changelog draft:** Run `uv run towncrier build --version=PREVIEW --draft` to preview the assembled changelog.
 

--- a/docs/changes/106.feature.md
+++ b/docs/changes/106.feature.md
@@ -1,1 +1,0 @@
-Add per-user CDCS record ownership: when `NX_CDCS_USER_OWNED_RECORDS=true`, uploaded records are assigned to the matching CDCS user account (looked up or created automatically from the NEMO session user), with workspace assignment controlled by the new `NX_CDCS_ASSIGN_TO_PUBLIC_WORKSPACE` setting.

--- a/docs/changes/108.bugfix.md
+++ b/docs/changes/108.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a bug where the `<sample>` element in built XML records was missing its `id` attribute, causing the `<sampleID>` references written into every acquisition activity to be dangling and unresolvable per the NexusLIMS schema.

--- a/nexusLIMS/builder/record_builder.py
+++ b/nexusLIMS/builder/record_builder.py
@@ -134,6 +134,17 @@ def build_record(
     for child in output:
         xml.append(child)
 
+    # Stamp each <sample> element with a unique id so that the <sampleID>
+    # references written into acquisition activities resolve correctly per the
+    # schema.  Elements produced by ReservationEvent.as_xml() carry no XML
+    # namespace in-memory, so we search without a namespace prefix here.
+    # The first sample receives sample_id (the value threaded into activities);
+    # any additional samples get fresh UUIDs so id values stay unique within
+    # the document.
+    for idx, sample_el in enumerate(xml.findall("sample")):
+        if not sample_el.get("id"):
+            sample_el.set("id", sample_id if idx == 0 else str(uuid4()))
+
     _logger.info(
         "Building acquisition activities for timespan from %s to %s",
         session.dt_from.isoformat(),

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -123,6 +123,19 @@ fi
 CURRENT_BRANCH=$(git branch --show-current)
 info "Current branch: $CURRENT_BRANCH"
 
+# Refuse to release from anything other than main
+if [ "$CURRENT_BRANCH" != "main" ]; then
+    error "Releases must be cut from the 'main' branch.\nCurrent branch: $CURRENT_BRANCH\n\nMerge all feature branches into main first, then re-run this script."
+fi
+
+# Verify main is up-to-date with origin
+git fetch origin main --quiet
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+if [ "$LOCAL" != "$REMOTE" ]; then
+    error "Local main is not in sync with origin/main.\nRun 'git pull origin main' to catch up, or push your local commits first."
+fi
+
 # Check if there are any towncrier fragments (both .md and legacy .rst)
 FRAGMENT_COUNT=$(find docs/changes \( -name '*.md' -o -name '*.rst' \) ! -name 'README.rst' ! -name 'README.md' 2>/dev/null | wc -l | tr -d ' ')
 if [ "$FRAGMENT_COUNT" -eq 0 ]; then

--- a/tests/integration/test_elabftw_integration.py
+++ b/tests/integration/test_elabftw_integration.py
@@ -331,7 +331,7 @@ class TestELabFTWClientIntegration:
         # Cleanup
         elabftw_client.delete_experiment(experiment_id)
 
-    def test_authentication_error(self):
+    def test_authentication_error(self, docker_services):
         """Test that invalid credentials raise authentication error."""
         bad_client = ELabFTWClient(base_url=ELABFTW_URL, api_key="invalid-key-12345")
 
@@ -557,7 +557,7 @@ class TestELabFTWDestinationIntegration:
         assert is_valid is True
         assert error_message is None
 
-    def test_validate_config_invalid_credentials(self, monkeypatch):
+    def test_validate_config_invalid_credentials(self, docker_services, monkeypatch):
         """Test configuration validation with invalid credentials."""
         # Configure with invalid credentials
         monkeypatch.setenv("NX_ELABFTW_URL", ELABFTW_URL)

--- a/tests/unit/test_record_builder/test_record_builder.py
+++ b/tests/unit/test_record_builder/test_record_builder.py
@@ -1072,6 +1072,43 @@ class TestRecordBuilder:
         # remove record
         f.unlink()
 
+    @pytest.mark.usefixtures("mock_nemo_reservation", "skip_preview_generation")
+    def test_build_record_sample_id_cross_reference(
+        self,
+        test_record_files,
+        monkeypatch,
+    ):
+        """Each <sample> element must have an id attribute that activities reference."""
+
+        def mock_get_sessions():
+            all_sessions = session_handler.get_sessions_to_build()
+            return [s for s in all_sessions if s.instrument.name == "TEST-TOOL"]
+
+        monkeypatch.setattr(record_builder, "get_sessions_to_build", mock_get_sessions)
+        monkeypatch.setattr(record_builder, "export_records", _mock_successful_export)
+
+        xml_files, *_ = record_builder.build_new_session_records()
+        assert len(xml_files) == 1
+        f = xml_files[0]
+        root = etree.parse(f)
+
+        sample_elements = root.findall(f".//{{{NX_NS}}}sample")
+        # The TEST-TOOL reservation has exactly one sample
+        assert len(sample_elements) == 1
+        sample_id = sample_elements[0].get("id")
+        assert sample_id is not None, "<sample> element must have an id attribute"
+
+        # The id must match the <sampleID> written into every activity
+        activity_sample_ids = {
+            el.text for el in root.findall(f".//{{{NX_NS}}}sampleID")
+        }
+        assert sample_id in activity_sample_ids, (
+            f"<sample id='{sample_id}'> is not referenced by any "
+            "<sampleID> in activities"
+        )
+
+        f.unlink()
+
     def test_build_record_with_sample_elements(
         self,
         test_record_files,
@@ -1171,6 +1208,24 @@ class TestRecordBuilder:
                 assert exp == this_element
             else:
                 assert [i.tag for i in this_element] == exp
+
+        # Each <sample> must have a unique id attribute so that the <sampleID>
+        # reference in activities resolves correctly per the schema.
+        sample_ids = [el.get("id") for el in sample_elements]
+        assert all(sid is not None for sid in sample_ids), (
+            "All <sample> elements must have an id attribute"
+        )
+        assert len(set(sample_ids)) == sample_count, (
+            "All <sample> id values must be unique within the document"
+        )
+        # The first sample's id must match the <sampleID> written into activities.
+        activity_sample_ids = {
+            el.text for el in root.findall(f".//{{{NX_NS}}}sampleID")
+        }
+        assert sample_ids[0] in activity_sample_ids, (
+            "The first sample's id must be referenced by at least one "
+            "activity <sampleID>"
+        )
 
         # remove record
         f.unlink()

--- a/uv.lock
+++ b/uv.lock
@@ -2262,7 +2262,7 @@ wheels = [
 
 [[package]]
 name = "nexuslims"
-version = "2.6.3.dev0"
+version = "2.7.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

- Fixes a bug where every built XML record had a dangling `<sampleID>` reference in acquisition activities — the `<sample>` element was never stamped with an `id` attribute, so the cross-reference was broken from the moment a record was created
- Guards `scripts/release.sh` (and the `/release` skill) against accidentally running from a non-main branch, which caused the v2.7.0 tag to land on a feature branch instead of main
- Fixes two eLabFTW integration tests that were missing the `docker_services` fixture, causing them to fail with connection errors instead of the expected 401 authentication error

## Changes

**`nexusLIMS/builder/record_builder.py`**
After appending reservation event children to the XML tree, `build_record` now iterates over all `<sample>` elements and sets their `id` attribute. The first sample receives the existing `sample_id` UUID (which activities already reference via `<sampleID>`); any additional samples get fresh UUIDs so `id` values remain unique within the document.

**`scripts/release.sh` / `.claude/commands/release.md`**
The release script now immediately errors if run from any branch other than `main`, and also verifies that local main is in sync with `origin/main`. The `/release` skill mirrors this as a pre-flight check before any tooling is invoked.

**`tests/integration/test_elabftw_integration.py`**
Added `docker_services` fixture to `test_authentication_error` and `test_validate_config_invalid_credentials`, which need eLabFTW running to receive a proper 401 response.

## Test plan

- [x] `test_build_record_sample_id_cross_reference` — new test verifying single-sample `id`/`sampleID` cross-reference
- [x] `test_build_record_with_sample_elements` — updated to assert all samples have unique `id` attributes and that the first sample's `id` is referenced by activities
- [x] Run `scripts/release.sh` from a feature branch to confirm it errors before making any changes
- [x] Run eLabFTW integration tests with Docker services up to confirm auth-error tests pass