### PR TITLE
Fix PR docs deploy after merged PRs

### DIFF
--- a/.github/workflows/deploy-pr-docs.yml
+++ b/.github/workflows/deploy-pr-docs.yml
@@ -25,7 +25,7 @@ jobs:
           if [[ "${{ github.event.workflow_run.conclusion }}" == "success" && \
                 "${{ github.event.workflow_run.event }}" == "pull_request" ]]; then
             echo "✅ Conditions met: will deploy PR documentation"
-            echo "should_deploy=true" >> $GITHUB_OUTPUT
+            echo "should_deploy=true" >> "$GITHUB_OUTPUT"
           else
             echo "⏭️  Skipping deployment:"
             if [[ "${{ github.event.workflow_run.conclusion }}" != "success" ]]; then
@@ -34,7 +34,7 @@ jobs:
             if [[ "${{ github.event.workflow_run.event }}" != "pull_request" ]]; then
               echo "  - Not triggered by a pull request (event: ${{ github.event.workflow_run.event }})"
             fi
-            echo "should_deploy=false" >> $GITHUB_OUTPUT
+            echo "should_deploy=false" >> "$GITHUB_OUTPUT"
           fi
 
   deploy-pr-docs:
@@ -162,14 +162,40 @@ jobs:
           cd pr-source
           ./scripts/build_docs.sh --strict
 
+      - name: Check PR is still open
+        id: pr-state
+        if: steps.pr.outputs.found == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number('${{ steps.pr.outputs.number }}');
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const isOpen = pullRequest.state === 'open';
+            core.setOutput('open', isOpen ? 'true' : 'false');
+
+            if (isOpen) {
+              console.log(`PR #${prNumber} is still open; deploying preview.`);
+            } else {
+              console.log(`PR #${prNumber} is ${pullRequest.state}; skipping preview deployment.`);
+            }
+
       - name: Deploy to PR preview directory
         # Create/update pr-{NUMBER} directory in gh-pages with docs
-        if: steps.pr.outputs.found == 'true'
+        if: steps.pr-state.outputs.open == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Stash any local changes (e.g., uv.lock modifications from uv sync)
           git stash --include-untracked || true
 
           PR_NUMBER=${{ steps.pr.outputs.number }}
+          git pull origin gh-pages --ff-only
+
           rm -rf "pr-${PR_NUMBER}"
           mkdir -p "pr-${PR_NUMBER}"
           rsync -avr pr-source/_build/ "pr-${PR_NUMBER}/"
@@ -211,14 +237,21 @@ jobs:
           git status
           git diff
 
-          git pull --rebase --strategy-option=theirs origin gh-pages
-          git push origin gh-pages
+          if ! git push origin gh-pages; then
+            PR_STATE=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq .state)
+            if [ "$PR_STATE" != "open" ]; then
+              echo "PR #${PR_NUMBER} is ${PR_STATE}; treating late preview push as skipped."
+              exit 0
+            fi
+            echo "Failed to push documentation preview for still-open PR #${PR_NUMBER}."
+            exit 1
+          fi
           echo "✅ Documentation preview deployed!"
           echo "🔗 View at: https://datasophos.github.io/NexusLIMS/pr-${PR_NUMBER}/"
 
       - name: Comment on PR
         # Post a comment with links to the deployed preview and coverage
-        if: steps.pr.outputs.found == 'true'
+        if: steps.pr-state.outputs.open == 'true'
         uses: actions/github-script@v7
         with:
           script: |

--- a/docs/changes/+pr-docs.bugfix.md
+++ b/docs/changes/+pr-docs.bugfix.md
@@ -1,0 +1,1 @@
+Skipped PR documentation preview deployment when the pull request has already closed, avoiding failed `gh-pages` updates after merge.


### PR DESCRIPTION
## Context

The PR documentation deployment can still be running after a PR is merged. In that window, the cleanup workflow may remove the PR preview directory from `gh-pages`, causing the late deploy to hit modify/delete conflicts while rebasing or pushing.

## Changes

- Check whether the PR is still open before deploying the preview or posting the preview comment.
- Pull the latest `gh-pages` before writing the preview directory.
- Treat a rejected late preview push as skipped when the PR has closed, while still failing for open PRs.
- Add a towncrier bugfix fragment.

## Testing

- `actionlint .github/workflows/deploy-pr-docs.yml`
- `env UV_CACHE_DIR=/private/tmp/uv-cache uv run towncrier build --draft`